### PR TITLE
Add a name to the V3 file-based SDS tls secret response

### DIFF
--- a/pkg/envoy/bootstrap/v3/bootstrap_test.go
+++ b/pkg/envoy/bootstrap/v3/bootstrap_test.go
@@ -63,7 +63,7 @@ func TestConfig_GenerateSdsResources(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"tls_certificate_sds_secret.json": `{"resources":[{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret","tls_certificate":{"certificate_chain":{"filename":"/tls.crt"},"private_key":{"filename":"/tls.key"}}}]}`,
+				"tls_certificate_sds_secret.json": `{"resources":[{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret","name":"xds_client_certificate","tls_certificate":{"certificate_chain":{"filename":"/tls.crt"},"private_key":{"filename":"/tls.key"}}}]}`,
 			},
 			wantErr: false,
 		},

--- a/pkg/envoy/resources/v3/resources.go
+++ b/pkg/envoy/resources/v3/resources.go
@@ -66,6 +66,7 @@ func (g Generator) NewSecret(name, privateKey, certificateChain string) envoy.Re
 func (g Generator) NewSecretFromPath(name, certificateChainPath, privateKeyPath string) envoy.Resource {
 
 	return &envoy_extensions_transport_sockets_tls_v3.Secret{
+		Name: name,
 		Type: &envoy_extensions_transport_sockets_tls_v3.Secret_TlsCertificate{
 			TlsCertificate: &envoy_extensions_transport_sockets_tls_v3.TlsCertificate{
 				CertificateChain: &envoy_config_core_v3.DataSource{


### PR DESCRIPTION
This applies only to the V3 protocol.

This impacts the tls_certificate_sds_secret.json config file, not the
response sent over the wire to xDS clients.

Marin3r generates this file and adds it to a k8s secret which is
mounted into Envoy pods. Envoy uses this file to retrieve the
bootstrap certs that allow it to talk to Marin3r over TLS. If there's
no "name" field then Envoy v0.17.0 can't process the cert, although
older Envoy versions can.

[2021-02-18 23:20:51.419][1][critical][main] [source/server/server.cc:109] error initializing configuration '/etc/envoy/bootstrap/config.json': Proto constraint validation failed (UpstreamTlsContextValidationError.CommonTlsContext: ["embe
dded message failed validation"] | caused by CommonTlsContextValidationError.TlsCertificateSdsSecretConfigs[i]: ["embedded message failed validation"] | caused by SdsSecretConfigValidationError.Name: ["value length must be at least " '\x0
1' " runes"]): common_tls_context {
  tls_certificate_sds_secret_configs {
    sds_config {
      path: "/etc/envoy/bootstrap/tls_certificate_sds_secret.json"
    }
  }
}

[2021-02-18 23:20:51.419][1][info][main] [source/server/server.cc:782] exiting
Proto constraint validation failed (UpstreamTlsContextValidationError.CommonTlsContext: ["embedded message failed validation"] | caused by CommonTlsContextValidationError.TlsCertificateSdsSecretConfigs[i]: ["embedded message failed valida
tion"] | caused by SdsSecretConfigValidationError.Name: ["value length must be at least " '\x01' " runes"]): common_tls_context {
  tls_certificate_sds_secret_configs {
    sds_config {
      path: "/etc/envoy/bootstrap/tls_certificate_sds_secret.json"
    }
  }
}

Thank you @roivaz for pointing me to this fix!