### PR TITLE
Drop usage of ManageError and ManageSuccess functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 # Project name
 NAME := marin3r
 # Current Operator version
-VERSION ?= 0.8.0-alpha.4
+VERSION ?= 0.8.0-alpha.5
 # Default bundle image tag
 BUNDLE_IMG ?= quay.io/3scale/marin3r-bundle:v$(VERSION)
 INDEX_IMG ?= quay.io/3scale/marin3r-catalog:latest

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,9 +6,9 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=marin3r
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.4.0+git
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/marin3r.clusterserviceversion.yaml
+++ b/bundle/manifests/marin3r.clusterserviceversion.yaml
@@ -138,7 +138,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale-ops/marin3r
     support: Red Hat, Inc.
-  name: marin3r.v0.8.0-alpha.4
+  name: marin3r.v0.8.0-alpha.5
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -687,7 +687,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/marin3r:v0.8.0-alpha.4
+                image: quay.io/3scale/marin3r:v0.8.0-alpha.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -732,7 +732,7 @@ spec:
                 - --tls-key-name=apiserver.key
                 command:
                 - /manager
-                image: quay.io/3scale/marin3r:v0.8.0-alpha.4
+                image: quay.io/3scale/marin3r:v0.8.0-alpha.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -1048,7 +1048,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 0.8.0-alpha.4
+  version: 0.8.0-alpha.5
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,9 +5,9 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: marin3r
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.4.0+git
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/marin3r
-  newTag: v0.8.0-alpha.4
+  newTag: v0.8.0-alpha.5

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -10,7 +10,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/marin3r
-  newTag: v0.8.0-alpha.4
+  newTag: v0.8.0-alpha.5
 
 patchesStrategicMerge:
 - |-

--- a/controllers/operator.marin3r/discoveryservice_controller.go
+++ b/controllers/operator.marin3r/discoveryservice_controller.go
@@ -81,7 +81,7 @@ func (r *DiscoveryServiceReconciler) Reconcile(ctx context.Context, request ctrl
 		err := r.GetClient().Update(ctx, ds)
 		if err != nil {
 			log.Error(err, "unable to initialize instance")
-			return r.ManageError(ctx, ds, err)
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}
@@ -93,13 +93,13 @@ func (r *DiscoveryServiceReconciler) Reconcile(ctx context.Context, request ctrl
 		err := r.ManageCleanUpLogic(ds, log)
 		if err != nil {
 			log.Error(err, "unable to delete instance")
-			return r.ManageError(ctx, ds, err)
+			return ctrl.Result{}, err
 		}
 		operatorutil.RemoveFinalizer(ds, operatorv1alpha1.Finalizer)
 		err = r.GetClient().Update(ctx, ds)
 		if err != nil {
 			log.Error(err, "unable to update instance")
-			return r.ManageError(ctx, ds, err)
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}
@@ -124,7 +124,7 @@ func (r *DiscoveryServiceReconciler) Reconcile(ctx context.Context, request ctrl
 
 	hash, err := r.calculateServerCertificateHash(ctx, util.ObjectKey(generate.ServerCertificate()()))
 	if err != nil {
-		return r.ManageError(ctx, ds, err)
+		return ctrl.Result{}, err
 	}
 
 	resources, err := r.NewLockedResources(
@@ -141,16 +141,16 @@ func (r *DiscoveryServiceReconciler) Reconcile(ctx context.Context, request ctrl
 		ds,
 	)
 	if err != nil {
-		return r.ManageError(ctx, ds, err)
+		return ctrl.Result{}, err
 	}
 
 	err = r.UpdateLockedResources(ctx, ds, resources, []lockedpatch.LockedPatch{})
 	if err != nil {
 		log.Error(err, "unable to update locked resources")
-		return r.ManageError(ctx, ds, err)
+		return ctrl.Result{}, err
 	}
 
-	return r.ManageSuccess(ctx, ds)
+	return ctrl.Result{}, nil
 }
 
 func (r *DiscoveryServiceReconciler) calculateServerCertificateHash(ctx context.Context, key types.NamespacedName) (string, error) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.8.0-alpha.4"
+	version string = "v0.8.0-alpha.5"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
ManageError(...) and ManageSuccess(...) from https://github.com/redhat-cop/operator-utils have functionality to manage the status of the custom resource after each reconcile, either for success or for error situations. We are not currently using this functionality as the status of marin3r custom resources does not support this.

Furthermore, ManageError is causing some spurious panics in reconcile loops when the custom resource cannot be retrieved for some reason. A first look into ManageError seems to point to the problem being that ManageError only restrains itslef from trying to access the fields in the custom resource if the api call returned a "not found" error. The panic occurs when a different api/client error is returned and then the function tries to access the struct, which just holds a nil value. The statement that ends up causing the panic is https://github.com/redhat-cop/operator-utils/blob/eca9bb2b140c4a08a13a5c570d5cdbcaa15a48b3/pkg/util/lockedresourcecontroller/resource-reconciler.go#L233