### PR TITLE
fix/operator-utils-panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,3 +25,5 @@ require (
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/controller-runtime v0.7.2
 )
+
+replace github.com/redhat-cop/operator-utils v1.1.2 => github.com/roivaz/operator-utils v1.1.3-0.20210518155433-82fe9bc469ab

--- a/go.sum
+++ b/go.sum
@@ -491,10 +491,10 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-cop/operator-utils v1.1.2 h1:jQjQs3U5ayzHPNFfiadEFmH/z/oE3OFJLJ9Kv++KH8U=
-github.com/redhat-cop/operator-utils v1.1.2/go.mod h1:d/7g1ZoiKNDjRjgUsqn7jzrWHKNCX2RNDbPmgXUgJN0=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/roivaz/operator-utils v1.1.3-0.20210518155433-82fe9bc469ab h1:mUgJ+5EjRr+0oTGxkn9mVi3AzaboPSQ0Y2ARLVn2tLE=
+github.com/roivaz/operator-utils v1.1.3-0.20210518155433-82fe9bc469ab/go.mod h1:Hu6OKop6iQfga0Hwrqv/03CQgpkcp55qwjMh9Gi0Iyk=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/pkg/envoy/container/shutdownmanager/manager.go
+++ b/pkg/envoy/container/shutdownmanager/manager.go
@@ -188,6 +188,7 @@ func (mgr *Manager) drainHandler(w http.ResponseWriter, r *http.Request) {
 		case <-time.After(mgr.CheckDrainInterval):
 		case <-ctx.Done():
 			l.Info("request cancelled")
+			w.WriteHeader(499)
 			return
 		}
 	}

--- a/pkg/envoy/container/shutdownmanager/manager_test.go
+++ b/pkg/envoy/container/shutdownmanager/manager_test.go
@@ -171,7 +171,7 @@ func TestManager_drainHandler(t *testing.T) {
 		mgr.EnvoyAdminAddress = fmt.Sprintf("http://localhost:%d", port)
 
 		// Create a request against shutdown manager /drain endpoint
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
 		req, err := http.NewRequestWithContext(ctx, "GET", DrainEndpoint, nil)
 		if err != nil {
@@ -191,7 +191,9 @@ func TestManager_drainHandler(t *testing.T) {
 		success := make(chan struct{})
 		go func() {
 			mgr.drainHandler(rr, req)
-			close(success)
+			if rr.Result().StatusCode == http.StatusOK {
+				close(success)
+			}
 		}()
 
 		// Block until success or timeout
@@ -201,6 +203,7 @@ func TestManager_drainHandler(t *testing.T) {
 		case <-success:
 			return nil
 		}
+
 	}
 
 	t.Run("Request should timeout (no metrics returned)", func(t *testing.T) {


### PR DESCRIPTION
Fixes a bug in `redhat-cop/operator-utils` library by temporarily poiniting to a forked version of the lib that includes a fix. PR https://github.com/redhat-cop/operator-utils/pull/68 also opened to fix this upstream.

Also fixed a flaky test.

/kind bug
/priority important-soon
/assign