### PR TITLE
Reimplement self-healing using internal statistics

### DIFF
--- a/controllers/marin3r/envoyconfigrevision_controller.go
+++ b/controllers/marin3r/envoyconfigrevision_controller.go
@@ -139,7 +139,7 @@ func (r *EnvoyConfigRevisionReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	if ecr.Status.Conditions.IsTrueFor(marin3rv1alpha1.RevisionPublishedCondition) {
-		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{Requeue: true, RequeueAfter: 60 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/marin3r/envoyconfigrevision_controller.go
+++ b/controllers/marin3r/envoyconfigrevision_controller.go
@@ -19,9 +19,11 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	xdss "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss"
+	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	envoy "github.com/3scale-ops/marin3r/pkg/envoy"
 	envoy_resources "github.com/3scale-ops/marin3r/pkg/envoy/resources"
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
@@ -44,11 +46,12 @@ import (
 
 // EnvoyConfigRevisionReconciler reconciles a EnvoyConfigRevision object
 type EnvoyConfigRevisionReconciler struct {
-	Client     client.Client
-	Log        logr.Logger
-	Scheme     *runtime.Scheme
-	XdsCache   xdss.Cache
-	APIVersion envoy.APIVersion
+	Client         client.Client
+	Log            logr.Logger
+	Scheme         *runtime.Scheme
+	XdsCache       xdss.Cache
+	APIVersion     envoy.APIVersion
+	DiscoveryStats *stats.Stats
 }
 
 // Reconcile progresses EnvoyConfigRevision resources to its desired state
@@ -85,7 +88,7 @@ func (r *EnvoyConfigRevisionReconciler) Reconcile(ctx context.Context, req ctrl.
 		if !controllerutil.ContainsFinalizer(ecr, marin3rv1alpha1.EnvoyConfigRevisionFinalizer) {
 			return reconcile.Result{}, nil
 		}
-		envoyconfigrevision.CleanupLogic(ecr, r.XdsCache, log)
+		envoyconfigrevision.CleanupLogic(ecr, r.XdsCache, r.DiscoveryStats, log)
 		controllerutil.RemoveFinalizer(ecr, marin3rv1alpha1.EnvoyConfigRevisionFinalizer)
 		if err = r.Client.Update(ctx, ecr); err != nil {
 			log.Error(err, "unable to update EnvoyConfigRevision")
@@ -128,16 +131,19 @@ func (r *EnvoyConfigRevisionReconciler) Reconcile(ctx context.Context, req ctrl.
 		}
 	}
 
-	if ok := envoyconfigrevision.IsStatusReconciled(ecr, vt, r.XdsCache); !ok {
+	if ok := envoyconfigrevision.IsStatusReconciled(ecr, vt, r.XdsCache, r.DiscoveryStats); !ok {
 		if err := r.Client.Status().Update(ctx, ecr); err != nil {
 			log.Error(err, "unable to update EnvoyConfigRevision status")
-			return ctrl.Result{}, err
 		}
 		log.Info("status updated for EnvoyConfigRevision resource")
-		return reconcile.Result{}, nil
+	}
+
+	if ecr.Status.Conditions.IsTrueFor(marin3rv1alpha1.RevisionPublishedCondition) {
+		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil
+
 }
 
 func (r *EnvoyConfigRevisionReconciler) taintSelf(ctx context.Context, ecr *marin3rv1alpha1.EnvoyConfigRevision,

--- a/controllers/marin3r/secrets_controller.go
+++ b/controllers/marin3r/secrets_controller.go
@@ -92,7 +92,6 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 						if err := r.Client.Status().Patch(ctx, &ecr, patch); err != nil {
 							return reconcile.Result{}, err
 						}
-						log.V(1).Info("Condition should have been added ...")
 					}
 				}
 			}

--- a/controllers/marin3r/suite_test.go
+++ b/controllers/marin3r/suite_test.go
@@ -24,6 +24,7 @@ import (
 
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	xdss_v2 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v2"
 	xdss_v3 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v3"
 	envoy "github.com/3scale-ops/marin3r/pkg/envoy"
@@ -106,22 +107,24 @@ var _ = BeforeSuite(func(done Done) {
 
 	// Add the EnvoyConfigRevision v2 controller
 	ecrV2Reconciler = &EnvoyConfigRevisionReconciler{
-		Client:     mgr.GetClient(),
-		Log:        ctrl.Log.WithName("controllers").WithName("envoyconfigrevision_v2"),
-		Scheme:     mgr.GetScheme(),
-		XdsCache:   xdss_v2.NewCache(cache_v2.NewSnapshotCache(true, cache_v2.IDHash{}, nil)),
-		APIVersion: envoy.APIv2,
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("envoyconfigrevision_v2"),
+		Scheme:         mgr.GetScheme(),
+		XdsCache:       xdss_v2.NewCache(cache_v2.NewSnapshotCache(true, cache_v2.IDHash{}, nil)),
+		APIVersion:     envoy.APIv2,
+		DiscoveryStats: stats.New(),
 	}
 	err = ecrV2Reconciler.SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Add the EnvoyConfigRevision v2 controller
 	ecrV3Reconciler = &EnvoyConfigRevisionReconciler{
-		Client:     mgr.GetClient(),
-		Log:        ctrl.Log.WithName("controllers").WithName("envoyconfigrevision_v3"),
-		Scheme:     mgr.GetScheme(),
-		XdsCache:   xdss_v3.NewCache(cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)),
-		APIVersion: envoy.APIv3,
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("envoyconfigrevision_v3"),
+		Scheme:         mgr.GetScheme(),
+		XdsCache:       xdss_v3.NewCache(cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)),
+		APIVersion:     envoy.APIv3,
+		DiscoveryStats: stats.New(),
 	}
 	err = ecrV3Reconciler.SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())

--- a/examples/local/envoy-client-bootstrap.yaml
+++ b/examples/local/envoy-client-bootstrap.yaml
@@ -8,6 +8,8 @@ admin:
 node:
   cluster: envoy1
   id: envoy1
+  metadata:
+    pod_name: "local"
 dynamic_resources:
   ads_config:
     api_type: GRPC

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/ginkgo v1.15.2
 	github.com/onsi/gomega v1.11.0
 	github.com/operator-framework/operator-lib v0.1.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/prometheus/common v0.10.0
 	github.com/redhat-cop/operator-utils v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -304,6 +304,7 @@ github.com/googleapis/gnostic v0.5.1 h1:A8Yhf6EtqTv9RMsU6MQTyrtV1TjWlR6xU9BsZIwu
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e h1:XmA6L9IPRdUr28a+SK/oMchGgQy159wvzXA5tJ7l+40=
 github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e/go.mod h1:AFIo+02s+12CEg8Gzz9kzhCbmbq6JcKNrhHffCGA9z4=
+github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -450,6 +451,8 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/operator-framework/operator-lib v0.1.0 h1:7Qy6v2ZccvCeFLWEkrGnN+U+DkaeIWp0gAZaBM9T3DI=
 github.com/operator-framework/operator-lib v0.1.0/go.mod h1:HLw61JTIEeq0YLeVf4dwYx/zt4DmLGZUVWI1y3Lf5Hg=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
@@ -505,6 +508,7 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -852,6 +856,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/discoveryservice/manager.go
+++ b/pkg/discoveryservice/manager.go
@@ -91,8 +91,6 @@ func (dsm *Manager) Start(ctx context.Context) {
 			ClientAuth:   tls.RequireAndVerifyClientCert,
 			ClientCAs:    loadCA(dsm.CACertificatePath, setupLog),
 		},
-		// rollback.OnError(mgr.GetClient()),
-		func(nodeID string, version string, msg string, envoyAPI envoy.APIVersion) error { return nil },
 		setupLog,
 	)
 

--- a/pkg/discoveryservice/manager.go
+++ b/pkg/discoveryservice/manager.go
@@ -114,22 +114,24 @@ func (dsm *Manager) Start(ctx context.Context) {
 	}
 
 	if err := (&marin3rcontroller.EnvoyConfigRevisionReconciler{
-		Client:     mgr.GetClient(),
-		Log:        ctrl.Log.WithName("controllers").WithName(fmt.Sprintf("envoyconfigrevision_%s", string(envoy.APIv2))),
-		Scheme:     mgr.GetScheme(),
-		XdsCache:   xdss.GetCache(envoy.APIv2),
-		APIVersion: envoy.APIv2,
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName(fmt.Sprintf("envoyconfigrevision_%s", string(envoy.APIv2))),
+		Scheme:         mgr.GetScheme(),
+		XdsCache:       xdss.GetCache(envoy.APIv2),
+		APIVersion:     envoy.APIv2,
+		DiscoveryStats: xdss.GetDiscoveryStats(envoy.APIv2),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", fmt.Sprintf("envoyconfigrevision_%s", string(envoy.APIv2)))
 		os.Exit(1)
 	}
 
 	if err := (&marin3rcontroller.EnvoyConfigRevisionReconciler{
-		Client:     mgr.GetClient(),
-		Log:        ctrl.Log.WithName("controllers").WithName(fmt.Sprintf("envoyconfigrevision_%s", string(envoy.APIv3))),
-		Scheme:     mgr.GetScheme(),
-		XdsCache:   xdss.GetCache(envoy.APIv3),
-		APIVersion: envoy.APIv3,
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName(fmt.Sprintf("envoyconfigrevision_%s", string(envoy.APIv3))),
+		Scheme:         mgr.GetScheme(),
+		XdsCache:       xdss.GetCache(envoy.APIv3),
+		APIVersion:     envoy.APIv3,
+		DiscoveryStats: xdss.GetDiscoveryStats(envoy.APIv3),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", fmt.Sprintf("envoyconfigrevision_%s", string(envoy.APIv3)))
 		os.Exit(1)

--- a/pkg/discoveryservice/xds_server_test.go
+++ b/pkg/discoveryservice/xds_server_test.go
@@ -88,6 +88,7 @@ func TestDualXdsServer_Start(t *testing.T) {
 				&xdss_v2.Callbacks{Logger: ctrl.Log},
 				&xdss_v3.Callbacks{Logger: ctrl.Log},
 				stats.New(),
+				stats.New(),
 			},
 		},
 	}
@@ -128,6 +129,7 @@ func TestDualXdsServer_GetCache(t *testing.T) {
 				&xdss_v2.Callbacks{Logger: ctrl.Log},
 				&xdss_v3.Callbacks{Logger: ctrl.Log},
 				stats.New(),
+				stats.New(),
 			},
 			xdss_v2.NewCache(snapshotCacheV2),
 			envoy.APIv2,
@@ -144,6 +146,7 @@ func TestDualXdsServer_GetCache(t *testing.T) {
 				snapshotCacheV3,
 				&xdss_v2.Callbacks{Logger: ctrl.Log},
 				&xdss_v3.Callbacks{Logger: ctrl.Log},
+				stats.New(),
 				stats.New(),
 			},
 			xdss_v3.NewCache(snapshotCacheV3),

--- a/pkg/discoveryservice/xds_server_test.go
+++ b/pkg/discoveryservice/xds_server_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	xdss "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss"
+	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	xdss_v2 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v2"
 	xdss_v3 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v3"
 	envoy "github.com/3scale-ops/marin3r/pkg/envoy"
@@ -45,7 +46,6 @@ func TestNewDualXdsServer(t *testing.T) {
 		ctx       context.Context
 		adsPort   uint
 		tlsConfig *tls.Config
-		fn        onErrorFn
 		logger    logr.Logger
 	}
 	tests := []struct {
@@ -54,12 +54,12 @@ func TestNewDualXdsServer(t *testing.T) {
 	}{
 		{
 			"Returns a new DualXdsServer from the given params",
-			args{context.Background(), 10000, &tls.Config{}, fn, ctrl.Log},
+			args{context.Background(), 10000, &tls.Config{}, ctrl.Log},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewDualXdsServer(tt.args.ctx, tt.args.adsPort, tt.args.tlsConfig, tt.args.fn, tt.args.logger)
+			got := NewDualXdsServer(tt.args.ctx, tt.args.adsPort, tt.args.tlsConfig, tt.args.logger)
 			if got.snapshotCacheV2 == nil || got.snapshotCacheV3 == nil ||
 				got.serverV2 == nil || got.serverV3 == nil ||
 				got.callbacksV2 == nil || got.callbacksV3 == nil {
@@ -87,6 +87,7 @@ func TestDualXdsServer_Start(t *testing.T) {
 				snapshotCacheV3,
 				&xdss_v2.Callbacks{Logger: ctrl.Log},
 				&xdss_v3.Callbacks{Logger: ctrl.Log},
+				stats.New(),
 			},
 		},
 	}
@@ -126,6 +127,7 @@ func TestDualXdsServer_GetCache(t *testing.T) {
 				snapshotCacheV3,
 				&xdss_v2.Callbacks{Logger: ctrl.Log},
 				&xdss_v3.Callbacks{Logger: ctrl.Log},
+				stats.New(),
 			},
 			xdss_v2.NewCache(snapshotCacheV2),
 			envoy.APIv2,
@@ -142,6 +144,7 @@ func TestDualXdsServer_GetCache(t *testing.T) {
 				snapshotCacheV3,
 				&xdss_v2.Callbacks{Logger: ctrl.Log},
 				&xdss_v3.Callbacks{Logger: ctrl.Log},
+				stats.New(),
 			},
 			xdss_v3.NewCache(snapshotCacheV3),
 			envoy.APIv3,

--- a/pkg/discoveryservice/xdss/stats/kv.go
+++ b/pkg/discoveryservice/xdss/stats/kv.go
@@ -1,0 +1,89 @@
+package stats
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	kv "github.com/patrickmn/go-cache"
+)
+
+const (
+	defaultExpiration = 0
+	cleanupInterval   = 10 * time.Minute
+)
+
+type Key struct {
+	NodeID       string
+	ResourceType string
+	Version      string
+	PodID        string
+	Key          string
+}
+
+func NewKey(nodeID, rType, version, podID, key string) *Key {
+	return &Key{
+		NodeID:       nodeID,
+		ResourceType: rType,
+		Version:      version,
+		PodID:        podID,
+		Key:          key,
+	}
+}
+
+func NewKeyFromString(key string) *Key {
+	values := strings.Split(key, ":")
+	return &Key{
+		NodeID:       values[0],
+		ResourceType: values[1],
+		Version:      values[2],
+		PodID:        values[3],
+		Key:          values[4],
+	}
+}
+
+func (k *Key) String() string {
+	return strings.Join([]string{k.NodeID, k.ResourceType, k.Version, k.PodID, k.Key}, ":")
+}
+
+func (s *Stats) GetString(nodeID, rtype, version, podID, key string) (string, error) {
+	k := NewKey(nodeID, rtype, version, podID, key).String()
+	if v, ok := s.store.Get(k); ok {
+		if value, ok := v.(string); !ok {
+			return "", fmt.Errorf("value of key '%s' is not a string", k)
+		} else {
+			return value, nil
+		}
+
+	} else {
+		return "", fmt.Errorf("key %s not found", k)
+	}
+}
+
+func (s *Stats) SetString(nodeID, rType, version, podID, key, value string) {
+	s.store.SetDefault(NewKey(nodeID, rType, version, podID, key).String(), value)
+}
+
+func (s *Stats) IncrementCounter(nodeID, rType, version, podID, key string, increment int64) {
+	if _, err := s.store.IncrementInt64(NewKey(nodeID, rType, version, podID, key).String(), increment); err != nil {
+		// The key does not exist yet in the kv store
+		s.store.SetDefault(NewKey(nodeID, rType, version, podID, key).String(), increment)
+	}
+}
+
+func (s *Stats) FilterKeys(filters ...string) map[string]kv.Item {
+	all := s.store.Items()
+	selected := map[string]kv.Item{}
+	for key, value := range all {
+		isSelected := true
+		for _, filter := range filters {
+			if !strings.Contains(key, filter) {
+				isSelected = false
+			}
+		}
+		if isSelected {
+			selected[key] = value
+		}
+	}
+	return selected
+}

--- a/pkg/discoveryservice/xdss/stats/kv_test.go
+++ b/pkg/discoveryservice/xdss/stats/kv_test.go
@@ -1,0 +1,390 @@
+package stats
+
+import (
+	"reflect"
+	"testing"
+
+	kv "github.com/patrickmn/go-cache"
+)
+
+func TestNewKey(t *testing.T) {
+	type args struct {
+		nodeID  string
+		version string
+		rType   string
+		podID   string
+		key     string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Key
+	}{
+		{
+			name: "Returns a Key struct",
+			args: args{
+				nodeID:  "node1",
+				rType:   "endpoint",
+				version: "aaaa",
+				podID:   "pod-xxxx",
+				key:     "key1",
+			},
+			want: &Key{
+				NodeID:       "node1",
+				ResourceType: "endpoint",
+				Version:      "aaaa",
+				PodID:        "pod-xxxx",
+				Key:          "key1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewKey(tt.args.nodeID, tt.args.rType, tt.args.version, tt.args.podID, tt.args.key); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewKeyFromString(t *testing.T) {
+	type args struct {
+		key string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Key
+	}{
+		{
+			name: "Returns a key struct",
+			args: args{
+				key: "node:endpoint:aaaa:pod-xxxx:key",
+			},
+			want: &Key{
+				NodeID:       "node",
+				ResourceType: "endpoint",
+				Version:      "aaaa",
+				PodID:        "pod-xxxx",
+				Key:          "key",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewKeyFromString(tt.args.key); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewKeyFromString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKey_String(t *testing.T) {
+	type fields struct {
+		NodeID       string
+		ResourceType string
+		Version      string
+		PodID        string
+		Key          string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "Returns the string representation of a Key",
+			fields: fields{
+				NodeID:       "node1",
+				ResourceType: "endpoint",
+				Version:      "aaaa",
+				PodID:        "pod-xxxx",
+				Key:          "key1",
+			},
+			want: "node1:endpoint:aaaa:pod-xxxx:key1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &Key{
+				NodeID:       tt.fields.NodeID,
+				ResourceType: tt.fields.ResourceType,
+				Version:      tt.fields.Version,
+				PodID:        tt.fields.PodID,
+				Key:          tt.fields.Key,
+			}
+			if got := k.String(); got != tt.want {
+				t.Errorf("Key.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStats_GetString(t *testing.T) {
+	type args struct {
+		nodeID  string
+		version string
+		rType   string
+		podID   string
+		key     string
+	}
+	tests := []struct {
+		name       string
+		cacheItems map[string]kv.Item
+		args       args
+		want       string
+		wantErr    bool
+	}{
+		{
+			name: "Returns a string value",
+			cacheItems: map[string]kv.Item{
+				"node1:endpoint:aaaa:pod-xxxx:key1": {Object: "item1", Expiration: int64(defaultExpiration)},
+				"node1:endpoint:aaaa:pod-xxxx:key2": {Object: "item2", Expiration: int64(defaultExpiration)},
+				"node1:endpoint:bbbb:pod-xxxx:key1": {Object: "item3", Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				nodeID:  "node1",
+				rType:   "endpoint",
+				version: "aaaa",
+				podID:   "pod-xxxx",
+				key:     "key1",
+			},
+			want:    "item1",
+			wantErr: false,
+		},
+		{
+			name: "Not a string error",
+			cacheItems: map[string]kv.Item{
+				"node1:endpoint:aaaa:pod-xxxx:key1": {Object: "item1", Expiration: int64(defaultExpiration)},
+				"node1:endpoint:aaaa:pod-xxxx:key2": {Object: 5, Expiration: int64(defaultExpiration)},
+				"node1:endpoint:bbbb:pod-xxxx:key1": {Object: "item3", Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				nodeID:  "node1",
+				rType:   "endpoint",
+				version: "aaaa",
+				podID:   "pod-xxxx",
+				key:     "key2",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:       "Not a found error",
+			cacheItems: map[string]kv.Item{},
+			args: args{
+				nodeID:  "node1",
+				rType:   "endpoint",
+				version: "aaaa",
+				podID:   "pod-xxxx",
+				key:     "key2",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Stats{store: kv.NewFrom(defaultExpiration, cleanupInterval, tt.cacheItems)}
+			got, err := s.GetString(tt.args.nodeID, tt.args.rType, tt.args.version, tt.args.podID, tt.args.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Stats.GetString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Stats.GetString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStats_SetString(t *testing.T) {
+
+	type args struct {
+		nodeID  string
+		version string
+		rType   string
+		podID   string
+		key     string
+		value   string
+	}
+	tests := []struct {
+		name       string
+		cacheItems map[string]kv.Item
+		args       args
+		want       kv.Item
+	}{
+		{
+			name:       "Writes a string key",
+			cacheItems: map[string]kv.Item{},
+			args: args{
+				nodeID:  "node",
+				rType:   "endpoint",
+				version: "aaaa",
+				podID:   "pod-xxxx",
+				key:     "key",
+				value:   "value",
+			},
+			want: kv.Item{
+				Object:     "value",
+				Expiration: 0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Stats{store: kv.NewFrom(defaultExpiration, cleanupInterval, tt.cacheItems)}
+			s.SetString(tt.args.nodeID, tt.args.rType, tt.args.version, tt.args.podID, tt.args.key, tt.args.value)
+			if got, _ := s.store.Get(NewKey(tt.args.nodeID, tt.args.rType, tt.args.version, tt.args.podID, tt.args.key).String()); got != tt.want.Object {
+				t.Errorf("Stats.SetString() = %v, want %v", got, tt.want.Object)
+			}
+		})
+	}
+}
+
+func TestStats_FilterKeys(t *testing.T) {
+	type args struct {
+		filters []string
+	}
+	tests := []struct {
+		name       string
+		cacheItems map[string]kv.Item
+		args       args
+		want       map[string]kv.Item
+	}{
+		{
+			name: "Selects one key that match the filter",
+			cacheItems: map[string]kv.Item{
+				"key1":        {Object: "item1", Expiration: int64(defaultExpiration)},
+				"key2:filter": {Object: "item2", Expiration: int64(defaultExpiration)},
+				"key3":        {Object: "item3", Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				filters: []string{"filter"},
+			},
+			want: map[string]kv.Item{
+				"key2:filter": {Object: "item2", Expiration: int64(defaultExpiration)},
+			},
+		},
+		{
+			name: "Selects several keys that match the filter",
+			cacheItems: map[string]kv.Item{
+				"key1":        {Object: "item1", Expiration: int64(defaultExpiration)},
+				"key2:filter": {Object: "item2", Expiration: int64(defaultExpiration)},
+				"key3:filter": {Object: "item3", Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				filters: []string{"filter"},
+			},
+			want: map[string]kv.Item{
+				"key2:filter": {Object: "item2", Expiration: int64(defaultExpiration)},
+				"key3:filter": {Object: "item3", Expiration: int64(defaultExpiration)},
+			},
+		},
+		{
+			name: "Selects one key that matches several filters",
+			cacheItems: map[string]kv.Item{
+				"key1":                 {Object: "item1", Expiration: int64(defaultExpiration)},
+				"key2:filter1:filter2": {Object: "item2", Expiration: int64(defaultExpiration)},
+				"key3:filter1":         {Object: "item3", Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				filters: []string{"filter1", "filter2"},
+			},
+			want: map[string]kv.Item{
+				"key2:filter1:filter2": {Object: "item2", Expiration: int64(defaultExpiration)},
+			},
+		},
+		{
+			name: "Selects several keys that matches several filters",
+			cacheItems: map[string]kv.Item{
+				"key1":                 {Object: "item1", Expiration: int64(defaultExpiration)},
+				"key2:filter1:filter2": {Object: "item2", Expiration: int64(defaultExpiration)},
+				"filter2:key3:filter1": {Object: "item3", Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				filters: []string{"filter1", "filter2"},
+			},
+			want: map[string]kv.Item{
+				"key2:filter1:filter2": {Object: "item2", Expiration: int64(defaultExpiration)},
+				"filter2:key3:filter1": {Object: "item3", Expiration: int64(defaultExpiration)},
+			},
+		},
+		{
+			name: "Selects no keys",
+			cacheItems: map[string]kv.Item{
+				"key1":                 {Object: "item1", Expiration: int64(defaultExpiration)},
+				"key2:filter1:filter2": {Object: "item2", Expiration: int64(defaultExpiration)},
+				"filter2:key3:filter1": {Object: "item3", Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				filters: []string{"filter1", "filter3"},
+			},
+			want: map[string]kv.Item{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Stats{store: kv.NewFrom(defaultExpiration, cleanupInterval, tt.cacheItems)}
+			if got := s.FilterKeys(tt.args.filters...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Stats.FilterKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStats_IncrementCounter(t *testing.T) {
+	type args struct {
+		nodeID    string
+		version   string
+		rType     string
+		podID     string
+		key       string
+		increment int64
+	}
+	tests := []struct {
+		name       string
+		cacheItems map[string]kv.Item
+		args       args
+		want       map[string]kv.Item
+	}{
+		{
+			name: "Increments a value",
+			cacheItems: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:key": {Object: int64(4), Expiration: int64(defaultExpiration)}},
+			args: args{
+				nodeID:    "node",
+				rType:     "endpoint",
+				version:   "aaaa",
+				podID:     "pod-xxxx",
+				key:       "key",
+				increment: 1,
+			},
+			want: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:key": {Object: int64(5), Expiration: int64(defaultExpiration)}},
+		},
+		{
+			name:       "Create value if it does not yet exist",
+			cacheItems: map[string]kv.Item{},
+			args: args{
+				nodeID:    "node",
+				rType:     "endpoint",
+				version:   "aaaa",
+				podID:     "pod-xxxx",
+				key:       "key",
+				increment: 1,
+			},
+			want: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:key": {Object: int64(1), Expiration: int64(defaultExpiration)}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Stats{store: kv.NewFrom(defaultExpiration, cleanupInterval, tt.cacheItems)}
+			s.IncrementCounter(tt.args.nodeID, tt.args.rType, tt.args.version, tt.args.podID, tt.args.key, tt.args.increment)
+			if got := s.store.Items(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Stats.IncrementCounter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/discoveryservice/xdss/stats/query.go
+++ b/pkg/discoveryservice/xdss/stats/query.go
@@ -1,0 +1,42 @@
+package stats
+
+import "math"
+
+func (s *Stats) GetSubscribedPods(nodeID, rType string) []string {
+
+	m := map[string]int8{}
+	items := s.FilterKeys(nodeID, rType, "request_counter")
+
+	for k := range items {
+		podID := NewKeyFromString(k).PodID
+		if _, ok := m[podID]; !ok {
+			m[podID] = 0
+		}
+	}
+
+	pods := make([]string, len(m))
+	i := 0
+	for k := range m {
+		pods[i] = k
+		i++
+	}
+
+	return pods
+}
+
+func (s *Stats) GetPercentageFailing(nodeID, rType, version string) float64 {
+
+	failing := 0
+	pods := s.GetSubscribedPods(nodeID, rType)
+	for _, pod := range pods {
+		if v, err := s.GetCounter(nodeID, rType, version, pod, "nack_counter"); err == nil && v > 0 {
+			failing++
+		}
+	}
+
+	val := float64(failing) / float64(len(pods))
+	if math.IsNaN(val) {
+		return 0
+	}
+	return val
+}

--- a/pkg/discoveryservice/xdss/stats/query_test.go
+++ b/pkg/discoveryservice/xdss/stats/query_test.go
@@ -1,0 +1,140 @@
+package stats
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	kv "github.com/patrickmn/go-cache"
+)
+
+func TestStats_GetSubscribedPods(t *testing.T) {
+	type args struct {
+		nodeID string
+		rType  string
+	}
+	tests := []struct {
+		name       string
+		cacheItems map[string]kv.Item
+		args       args
+		want       []string
+	}{
+		{
+			name: "",
+			cacheItems: map[string]kv.Item{
+				"node:endpoint:*:pod-xxxx:request_counter:stream_1": {Object: int64(1), Expiration: int64(defaultExpiration)},
+				"node:cluster:*:pod-xxxx:request_counter:stream_2":  {Object: int64(1), Expiration: int64(defaultExpiration)},
+				"node:cluster:*:pod-yyyy:request_counter":           {Object: int64(1), Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				nodeID: "node",
+				rType:  "cluster",
+			},
+			want: []string{"pod-xxxx", "pod-yyyy"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Stats{store: kv.NewFrom(defaultExpiration, cleanupInterval, tt.cacheItems)}
+			got := s.GetSubscribedPods(tt.args.nodeID, tt.args.rType)
+			sort.Strings(got)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Stats.GetSubscribedPods() = %v, want %v", sort.StringSlice(got), sort.StringSlice(tt.want))
+			}
+		})
+	}
+}
+
+func TestStats_GetPercentageFailing(t *testing.T) {
+	type args struct {
+		nodeID  string
+		rType   string
+		version string
+	}
+	tests := []struct {
+		name       string
+		cacheItems map[string]kv.Item
+		args       args
+		want       float64
+	}{
+		{
+			name: "Returns 50%",
+			cacheItems: map[string]kv.Item{
+				"node:endpoint:*:pod-aaaa:request_counter:stream_1": {Object: int64(2), Expiration: int64(defaultExpiration)},
+				"node:endpoint:*:pod-bbbb:request_counter:stream_2": {Object: int64(5), Expiration: int64(defaultExpiration)},
+				"node:endpoint:*:pod-cccc:request_counter:stream_3": {Object: int64(1), Expiration: int64(defaultExpiration)},
+				"node:endpoint:*:pod-dddd:request_counter:stream_4": {Object: int64(1), Expiration: int64(defaultExpiration)},
+				"node:endpoint:xxxx:pod-aaaa:nack_counter":          {Object: int64(1), Expiration: int64(defaultExpiration)},
+				"node:endpoint:xxxx:pod-bbbb:nack_counter":          {Object: int64(10), Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				nodeID:  "node",
+				rType:   "endpoint",
+				version: "xxxx",
+			},
+			want: 0.5,
+		},
+		{
+			name: "Returns 100%",
+			cacheItems: map[string]kv.Item{
+				"node:endpoint:*:pod-aaaa:request_counter:stream_1": {Object: int64(2), Expiration: int64(defaultExpiration)},
+				"node:endpoint:*:pod-bbbb:request_counter:stream_2": {Object: int64(5), Expiration: int64(defaultExpiration)},
+				"node:endpoint:*:pod-cccc:request_counter:stream_3": {Object: int64(1), Expiration: int64(defaultExpiration)},
+				"node:endpoint:*:pod-dddd:request_counter:stream_4": {Object: int64(1), Expiration: int64(defaultExpiration)},
+				"node:endpoint:xxxx:pod-aaaa:nack_counter":          {Object: int64(1), Expiration: int64(defaultExpiration)},
+				"node:endpoint:xxxx:pod-bbbb:nack_counter":          {Object: int64(10), Expiration: int64(defaultExpiration)},
+				"node:endpoint:xxxx:pod-cccc:nack_counter":          {Object: int64(10), Expiration: int64(defaultExpiration)},
+				"node:endpoint:xxxx:pod-dddd:nack_counter":          {Object: int64(10), Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				nodeID:  "node",
+				rType:   "endpoint",
+				version: "xxxx",
+			},
+			want: 1,
+		},
+		{
+			name: "Returns 0%",
+			cacheItems: map[string]kv.Item{
+				"node:endpoint:*:pod-aaaa:request_counter:stream_1": {Object: int64(2), Expiration: int64(defaultExpiration)},
+				"node:endpoint:*:pod-bbbb:request_counter:stream_2": {Object: int64(5), Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				nodeID:  "node",
+				rType:   "endpoint",
+				version: "xxxx",
+			},
+			want: 0,
+		},
+		{
+			name:       "Returns 0%",
+			cacheItems: map[string]kv.Item{},
+			args: args{
+				nodeID:  "node",
+				rType:   "endpoint",
+				version: "xxxx",
+			},
+			want: 0,
+		},
+		{
+			name: "Returns 0% if NaN",
+			cacheItems: map[string]kv.Item{
+				"node:endpoint:xxxx:pod-aaaa:nack_counter": {Object: int64(1), Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				nodeID:  "node",
+				rType:   "endpoint",
+				version: "xxxx",
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Stats{store: kv.NewFrom(defaultExpiration, cleanupInterval, tt.cacheItems)}
+			if got := s.GetPercentageFailing(tt.args.nodeID, tt.args.rType, tt.args.version); got != tt.want {
+				t.Errorf("Stats.GetPercentageFailing() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/discoveryservice/xdss/stats/report.go
+++ b/pkg/discoveryservice/xdss/stats/report.go
@@ -1,0 +1,42 @@
+package stats
+
+import "fmt"
+
+func (s *Stats) WriteResponseNonce(nodeID, rType, version, podID, nonce string) {
+	s.SetString(nodeID, rType, version, podID, fmt.Sprintf("nonce:%s", nonce), "")
+}
+
+func (s *Stats) ReportNACK(nodeID, rType, podID, nonce string) error {
+	keys := s.FilterKeys(nodeID, rType, podID, fmt.Sprintf("nonce:%s", nonce))
+	if len(keys) != 1 {
+		return fmt.Errorf("error reporting failure: unexpected number of nonces in the cache")
+	}
+
+	// The value fo version is container in the key of the corresponding nonce stored
+	// in the cache
+	version := NewKeyFromString(func() string {
+		for k := range keys {
+			return k
+		}
+		return ""
+	}()).Version
+
+	s.IncrementCounter(nodeID, rType, version, podID, "nack_counter", 1)
+	return nil
+}
+
+func (s *Stats) ReportACK(nodeID, rType, version, podID string) {
+	s.IncrementCounter(nodeID, rType, version, podID, "ack_counter", 1)
+}
+
+func GetStringValueFromMetadata(meta map[string]interface{}, key string) (string, error) {
+
+	v, ok := meta[key]
+	if !ok {
+		return "", fmt.Errorf("missing 'pod_name' in node's metadata")
+	} else if _, ok := v.(string); !ok {
+		return "", fmt.Errorf("metadata value is not a string")
+	}
+
+	return v.(string), nil
+}

--- a/pkg/discoveryservice/xdss/stats/report.go
+++ b/pkg/discoveryservice/xdss/stats/report.go
@@ -1,15 +1,18 @@
 package stats
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 func (s *Stats) WriteResponseNonce(nodeID, rType, version, podID, nonce string) {
-	s.SetString(nodeID, rType, version, podID, fmt.Sprintf("nonce:%s", nonce), "")
+	s.SetStringWithExpiration(nodeID, rType, version, podID, fmt.Sprintf("nonce:%s", nonce), "", 10*time.Second)
 }
 
-func (s *Stats) ReportNACK(nodeID, rType, podID, nonce string) error {
+func (s *Stats) ReportNACK(nodeID, rType, podID, nonce string) (int64, error) {
 	keys := s.FilterKeys(nodeID, rType, podID, fmt.Sprintf("nonce:%s", nonce))
 	if len(keys) != 1 {
-		return fmt.Errorf("error reporting failure: unexpected number of nonces in the cache")
+		return 0, fmt.Errorf("error reporting failure: unexpected number of nonces in the cache")
 	}
 
 	// The value fo version is container in the key of the corresponding nonce stored
@@ -22,11 +25,19 @@ func (s *Stats) ReportNACK(nodeID, rType, podID, nonce string) error {
 	}()).Version
 
 	s.IncrementCounter(nodeID, rType, version, podID, "nack_counter", 1)
-	return nil
+	return s.GetCounter(nodeID, rType, version, podID, "nack_counter")
 }
 
 func (s *Stats) ReportACK(nodeID, rType, version, podID string) {
 	s.IncrementCounter(nodeID, rType, version, podID, "ack_counter", 1)
+}
+
+func (s *Stats) ReportRequest(nodeID, rType, podID string, streamID int64) {
+	s.IncrementCounter(nodeID, rType, "*", podID, fmt.Sprintf("request_counter:stream_%d", streamID), 1)
+}
+
+func (s *Stats) ReportStreamClosed(streamID int64) {
+	s.DeleteKeysByFilter(fmt.Sprintf("request_counter:stream_%d", streamID))
 }
 
 func GetStringValueFromMetadata(meta map[string]interface{}, key string) (string, error) {

--- a/pkg/discoveryservice/xdss/stats/report.go
+++ b/pkg/discoveryservice/xdss/stats/report.go
@@ -15,7 +15,7 @@ func (s *Stats) ReportNACK(nodeID, rType, podID, nonce string) (int64, error) {
 		return 0, fmt.Errorf("error reporting failure: unexpected number of nonces in the cache")
 	}
 
-	// The value fo version is container in the key of the corresponding nonce stored
+	// The value of version is container in the key of the corresponding nonce stored
 	// in the cache
 	version := NewKeyFromString(func() string {
 		for k := range keys {

--- a/pkg/discoveryservice/xdss/stats/report_test.go
+++ b/pkg/discoveryservice/xdss/stats/report_test.go
@@ -1,0 +1,215 @@
+package stats
+
+import (
+	"reflect"
+	"testing"
+
+	kv "github.com/patrickmn/go-cache"
+)
+
+func TestStats_WriteResponseNonce(t *testing.T) {
+	type args struct {
+		nodeID  string
+		version string
+		podID   string
+		rType   string
+		nonce   string
+	}
+	tests := []struct {
+		name       string
+		cacheItems map[string]kv.Item
+		args       args
+		want       map[string]kv.Item
+	}{
+		{
+			name:       "Writes the nonce",
+			cacheItems: map[string]kv.Item{},
+			args: args{
+				nodeID:  "node",
+				rType:   "endpoint",
+				version: "aaaa",
+				podID:   "pod-xxxx",
+				nonce:   "7",
+			},
+			want: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:nonce:7": {Object: "", Expiration: int64(defaultExpiration)}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Stats{store: kv.NewFrom(defaultExpiration, cleanupInterval, tt.cacheItems)}
+			s.WriteResponseNonce(tt.args.nodeID, tt.args.rType, tt.args.version, tt.args.podID, tt.args.nonce)
+			if got := s.store.Items(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Stats.WriteResponseNonce() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStats_ReportNACK(t *testing.T) {
+	type args struct {
+		nodeID string
+		rType  string
+		podID  string
+		nonce  string
+	}
+	tests := []struct {
+		name       string
+		cacheItems map[string]kv.Item
+		args       args
+		want       map[string]kv.Item
+		wantErr    bool
+	}{
+		{
+			name: "Increments a NACK counter",
+			cacheItems: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:nonce:7":      {Object: "", Expiration: int64(defaultExpiration)},
+				"node:endpoint:aaaa:pod-xxxx:nack_counter": {Object: int64(5), Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				nodeID: "node",
+				rType:  "endpoint",
+				podID:  "pod-xxxx",
+				nonce:  "7",
+			},
+			want: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:nonce:7":      {Object: "", Expiration: int64(defaultExpiration)},
+				"node:endpoint:aaaa:pod-xxxx:nack_counter": {Object: int64(6), Expiration: int64(defaultExpiration)},
+			},
+		},
+		{
+			name: "Creates a new NACK counter",
+			cacheItems: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:nonce:xyz": {Object: "", Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				nodeID: "node",
+				rType:  "endpoint",
+				podID:  "pod-xxxx",
+				nonce:  "xyz",
+			},
+			want: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:nonce:xyz":    {Object: "", Expiration: int64(defaultExpiration)},
+				"node:endpoint:aaaa:pod-xxxx:nack_counter": {Object: int64(1), Expiration: int64(defaultExpiration)},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Stats{store: kv.NewFrom(defaultExpiration, cleanupInterval, tt.cacheItems)}
+			if err := s.ReportNACK(tt.args.nodeID, tt.args.rType, tt.args.podID, tt.args.nonce); (err != nil) != tt.wantErr {
+				t.Errorf("Stats.ReportNACK() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got := s.store.Items(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Stats.ReportNACK() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStats_ReportACK(t *testing.T) {
+	type args struct {
+		nodeID  string
+		podID   string
+		version string
+		rType   string
+	}
+	tests := []struct {
+		name       string
+		cacheItems map[string]kv.Item
+		args       args
+		want       map[string]kv.Item
+	}{
+		{
+			name: "Increments a NACK counter",
+			cacheItems: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:ack_counter": {Object: int64(5), Expiration: int64(defaultExpiration)},
+			},
+			args: args{
+				nodeID: "node",
+				rType:  "endpoint",
+				podID:  "pod-xxxx",
+			},
+			want: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:ack_counter": {Object: int64(6), Expiration: int64(defaultExpiration)},
+			},
+		},
+		{
+			name:       "Creates a NACK counter",
+			cacheItems: map[string]kv.Item{},
+			args: args{
+				nodeID: "node",
+				rType:  "endpoint",
+				podID:  "pod-xxxx",
+			},
+			want: map[string]kv.Item{
+				"node:endpoint:aaaa:pod-xxxx:ack_counter": {Object: int64(1), Expiration: int64(defaultExpiration)},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Stats{store: kv.NewFrom(defaultExpiration, cleanupInterval, tt.cacheItems)}
+			s.ReportACK(tt.args.nodeID, tt.args.podID, tt.args.version, tt.args.rType)
+		})
+	}
+}
+
+func TestGetStringValueFromMetadata(t *testing.T) {
+	type args struct {
+		meta map[string]interface{}
+		key  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Returns the metadata value as a string",
+			args: args{
+				meta: map[string]interface{}{
+					"meta_key": func() interface{} { s := "name"; return s }(),
+				},
+				key: "meta_key",
+			},
+			want:    "name",
+			wantErr: false,
+		},
+		{
+			name: "Not a string value",
+			args: args{
+				meta: map[string]interface{}{
+					"meta_key": func() interface{} { s := 3; return s }(),
+				},
+				key: "meta_key",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Not found",
+			args: args{
+				meta: map[string]interface{}{
+					"meta_key": func() interface{} { s := "name"; return s }(),
+				},
+				key: "other_key",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetStringValueFromMetadata(tt.args.meta, tt.args.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetStringValueFromMetadata() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetStringValueFromMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/discoveryservice/xdss/stats/stats.go
+++ b/pkg/discoveryservice/xdss/stats/stats.go
@@ -1,0 +1,21 @@
+package stats
+
+import (
+	kv "github.com/patrickmn/go-cache"
+)
+
+// The format of the keys in the cache is
+//   <node-id>:<version>:<resource-type>:<pod-id>:<key>
+//
+// Note that though currently revision and version have the same value for all
+// types (with the execption of secrets), this might change in the future and have
+// each resource type follow its own versioning
+type Stats struct {
+	store *kv.Cache
+}
+
+func New() *Stats {
+	return &Stats{
+		store: kv.New(defaultExpiration, cleanupInterval),
+	}
+}

--- a/pkg/discoveryservice/xdss/stats/stats.go
+++ b/pkg/discoveryservice/xdss/stats/stats.go
@@ -19,3 +19,9 @@ func New() *Stats {
 		store: kv.New(defaultExpiration, cleanupInterval),
 	}
 }
+
+func NewWithItems(items map[string]kv.Item) *Stats {
+	return &Stats{
+		store: kv.NewFrom(defaultExpiration, cleanupInterval, items),
+	}
+}

--- a/pkg/discoveryservice/xdss/stats/stats.go
+++ b/pkg/discoveryservice/xdss/stats/stats.go
@@ -8,7 +8,7 @@ import (
 //   <node-id>:<version>:<resource-type>:<pod-id>:<key>
 //
 // Note that though currently revision and version have the same value for all
-// types (with the execption of secrets), this might change in the future and have
+// types (with the exeption of secrets), this might change in the future and have
 // each resource type follow its own versioning
 type Stats struct {
 	store *kv.Cache

--- a/pkg/discoveryservice/xdss/v2/cache.go
+++ b/pkg/discoveryservice/xdss/v2/cache.go
@@ -2,13 +2,15 @@ package discoveryservice
 
 import (
 	xdss "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss"
+	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	cache_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cache_v2 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 )
 
 // Cache implements "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss".Cache for envoy API v2.
 type Cache struct {
-	v2 cache_v2.SnapshotCache
+	v2    cache_v2.SnapshotCache
+	Stats stats.Stats
 }
 
 // NewCache returns a Cache object.

--- a/pkg/discoveryservice/xdss/v2/callbacks.go
+++ b/pkg/discoveryservice/xdss/v2/callbacks.go
@@ -16,11 +16,13 @@ package discoveryservice
 
 import (
 	"context"
+	"time"
 
 	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
 	envoy_resources_v2 "github.com/3scale-ops/marin3r/pkg/envoy/resources/v2"
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
+	"github.com/3scale-ops/marin3r/pkg/util/backoff"
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/go-logr/logr"
 )
@@ -62,8 +64,16 @@ func (cb *Callbacks) OnStreamRequest(id int64, req *envoy_api_v2.DiscoveryReques
 	if req.GetResponseNonce() != "" {
 		if req.GetErrorDetail() != nil {
 			log.Info("Discovery NACK")
-			if err := cb.Stats.ReportNACK(req.GetNode().GetId(), req.GetTypeUrl(), podName, req.GetResponseNonce()); err != nil {
+			failures, err := cb.Stats.ReportNACK(req.GetNode().GetId(), req.GetTypeUrl(), podName, req.GetResponseNonce())
+			if err != nil {
 				log.Error(err, "error trying to report a response NACK")
+			}
+
+			// Backoff
+			if failures == 0 {
+				time.Sleep(100 * time.Millisecond)
+			} else {
+				time.Sleep(backoff.Default.Duration(int(failures)))
 			}
 
 		} else {

--- a/pkg/discoveryservice/xdss/v2/callbacks.go
+++ b/pkg/discoveryservice/xdss/v2/callbacks.go
@@ -42,6 +42,7 @@ func (cb *Callbacks) OnStreamOpen(ctx context.Context, id int64, typ string) err
 // OnStreamClosed is called immediately prior to closing an xDS stream with a stream ID.
 func (cb *Callbacks) OnStreamClosed(id int64) {
 	cb.Logger.V(1).Info("Stream closed", "StreamID", id)
+	cb.Stats.ReportStreamClosed(id)
 }
 
 // OnStreamRequest implements go-control-plane/pkg/server/Callbacks.OnStreamRequest
@@ -52,6 +53,7 @@ func (cb *Callbacks) OnStreamRequest(id int64, req *envoy_api_v2.DiscoveryReques
 	podName, err := stats.GetStringValueFromMetadata(req.GetNode().Metadata.AsMap(), "pod_name")
 	if err != nil {
 		cb.Logger.Error(err, "an error ocurred, Pod name could not be retrieved", "NodeID", req.GetNode().GetId(), "StreamID", id)
+		podName = "unknown"
 	}
 
 	log := cb.Logger.WithValues("TypeURL", req.GetTypeUrl(), "NodeID", req.GetNode().GetId(), "StreamID", id,
@@ -71,6 +73,7 @@ func (cb *Callbacks) OnStreamRequest(id int64, req *envoy_api_v2.DiscoveryReques
 
 	} else {
 		log.Info("Discovery Request")
+		cb.Stats.ReportRequest(req.GetNode().GetId(), req.GetTypeUrl(), podName, id)
 	}
 
 	return nil

--- a/pkg/discoveryservice/xdss/v2/callbacks.go
+++ b/pkg/discoveryservice/xdss/v2/callbacks.go
@@ -16,21 +16,19 @@ package discoveryservice
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
 	envoy_resources_v2 "github.com/3scale-ops/marin3r/pkg/envoy/resources/v2"
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	cache_v2 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	"github.com/go-logr/logr"
 )
 
 // Callbacks is a type that implements "go-control-plane/pkg/server/".Callbacks
 type Callbacks struct {
-	OnError       func(nodeID, previousVersion, msg string, envoyAPI envoy.APIVersion) error
-	SnapshotCache *cache_v2.SnapshotCache
-	Logger        logr.Logger
+	Stats  *stats.Stats
+	Logger logr.Logger
 }
 
 // OnStreamOpen implements go-control-plane/pkg/server/Callbacks.OnStreamOpen
@@ -50,38 +48,58 @@ func (cb *Callbacks) OnStreamClosed(id int64) {
 // OnStreamRequest is called once a request is received on a stream.
 // Returning an error will end processing and close the stream. OnStreamClosed will still be called.
 func (cb *Callbacks) OnStreamRequest(id int64, req *envoy_api_v2.DiscoveryRequest) error {
-	cb.Logger.V(1).Info("Received request", "ResourceNames", req.ResourceNames, "Version", req.VersionInfo, "TypeURL", req.TypeUrl, "NodeID", req.Node.Id, "StreamID", id)
-
-	if req.ErrorDetail != nil {
-		snap, err := (*cb.SnapshotCache).GetSnapshot(req.Node.Id)
-		if err != nil {
-			return err
-		}
-		// All resource types are always kept at the same version
-		failingVersion := snap.GetVersion(req.TypeUrl)
-		cb.Logger.Error(fmt.Errorf(req.ErrorDetail.Message), "A gateway reported an error", "CurrentVersion", req.VersionInfo, "FailingVersion", failingVersion, "NodeID", req.Node.Id, "StreamID", id)
-		if err := cb.OnError(req.Node.Id, failingVersion, req.ErrorDetail.Message, envoy.APIv2); err != nil {
-			cb.Logger.Error(err, "Error calling OnErrorFn", "NodeID", req.Node.Id, "StreamID", id)
-			return err
-		}
+	// Try to get the Pod name associated with the request
+	podName, err := stats.GetStringValueFromMetadata(req.GetNode().Metadata.AsMap(), "pod_name")
+	if err != nil {
+		cb.Logger.Error(err, "an error ocurred, Pod name could not be retrieved", "NodeID", req.GetNode().GetId(), "StreamID", id)
 	}
+
+	log := cb.Logger.WithValues("TypeURL", req.GetTypeUrl(), "NodeID", req.GetNode().GetId(), "StreamID", id,
+		"Pod", podName, "ResourceNames", req.GetResourceNames(), "LastAcceptedVersion", req.GetVersionInfo())
+
+	if req.GetResponseNonce() != "" {
+		if req.GetErrorDetail() != nil {
+			log.Info("Discovery NACK")
+			if err := cb.Stats.ReportNACK(req.GetNode().GetId(), req.GetTypeUrl(), podName, req.GetResponseNonce()); err != nil {
+				log.Error(err, "error trying to report a response NACK")
+			}
+
+		} else {
+			log.Info("Discovery ACK")
+			cb.Stats.ReportACK(req.GetNode().GetId(), req.GetTypeUrl(), req.GetVersionInfo(), podName)
+		}
+
+	} else {
+		log.Info("Discovery Request")
+	}
+
 	return nil
 }
 
 // OnStreamResponse implements go-control-plane/pkgserver/Callbacks.OnStreamResponse
 // OnStreamResponse is called immediately prior to sending a response on a stream.
 func (cb *Callbacks) OnStreamResponse(id int64, req *envoy_api_v2.DiscoveryRequest, rsp *envoy_api_v2.DiscoveryResponse) {
+	log := cb.Logger.WithValues("TypeURL", req.GetTypeUrl(), "NodeID", req.GetNode().GetId(), "StreamID", id, "Version", rsp.GetVersionInfo())
+
+	// Track the nonce of this response in the stats cache
+	podName, err := stats.GetStringValueFromMetadata(req.GetNode().Metadata.AsMap(), "pod_name")
+	if err != nil {
+		log.Error(err, "an error ocurred, nonce won't be tracked")
+	} else {
+		cb.Stats.WriteResponseNonce(req.GetNode().GetId(), rsp.GetTypeUrl(), rsp.GetVersionInfo(), podName, rsp.GetNonce())
+	}
+
+	// Log resources when in debug mode
 	resources := []string{}
 	for _, r := range rsp.Resources {
 		j, _ := envoy_serializer.NewResourceMarshaller(envoy_serializer.JSON, envoy.APIv2).Marshal(r)
 		resources = append(resources, string(j))
 	}
 	if rsp.TypeUrl == envoy_resources_v2.Mappings()[envoy.Secret] {
-		cb.Logger.V(1).Info("Response sent to gateway",
-			"ResourcesNames", req.ResourceNames, "TypeURL", req.TypeUrl, "NodeID", req.Node.Id, "StreamID", id, "Version", rsp.GetVersionInfo())
+		// Do not log secret contents
+		log.V(1).Info("Discovery Response", "ResourcesNames", req.ResourceNames, "Pod", podName)
 	} else {
-		cb.Logger.V(1).Info("Response sent to gateway",
-			"Resources", resources, "TypeURL", req.TypeUrl, "NodeID", req.Node.Id, "StreamID", id, "Version", rsp.GetVersionInfo())
+		log.V(1).Info("Discovery Response", "Resources", resources, "Pod", podName)
 	}
 }
 

--- a/pkg/discoveryservice/xdss/v2/callbacks_test.go
+++ b/pkg/discoveryservice/xdss/v2/callbacks_test.go
@@ -65,7 +65,10 @@ func TestCallbacks_OnStreamOpen(t *testing.T) {
 	}{
 		{
 			"OnStreamOpen()",
-			&Callbacks{Logger: ctrl.Log},
+			&Callbacks{
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
+			},
 			args{context.Background(), 1, "xxxx"},
 			false,
 		},
@@ -90,7 +93,10 @@ func TestCallbacks_OnStreamClosed(t *testing.T) {
 	}{
 		{
 			"OnStreamClosed()",
-			&Callbacks{Logger: ctrl.Log},
+			&Callbacks{
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
+			},
 			args{1},
 		}}
 	for _, tt := range tests {
@@ -113,7 +119,10 @@ func TestCallbacks_OnStreamRequest(t *testing.T) {
 	}{
 		{
 			"OnStreamRequest()",
-			&Callbacks{Logger: ctrl.Log},
+			&Callbacks{
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
+			},
 			args{1, &envoy_api_v2.DiscoveryRequest{
 				Node:          &envoy_api_v2_core.Node{Id: "node1", Cluster: "cluster1"},
 				ResourceNames: []string{"string1", "string2"},
@@ -159,7 +168,10 @@ func TestCallbacks_OnStreamResponse(t *testing.T) {
 	}{
 		{
 			"OnStreamResponse()",
-			&Callbacks{Logger: ctrl.Log},
+			&Callbacks{
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
+			},
 			args{1,
 				&envoy_api_v2.DiscoveryRequest{
 					Node:          &envoy_api_v2_core.Node{Id: "node1", Cluster: "cluster1"},
@@ -177,8 +189,10 @@ func TestCallbacks_OnStreamResponse(t *testing.T) {
 		},
 		{
 			"OnStreamResponse() special treatment of secret resources",
-			&Callbacks{Logger: ctrl.Log},
-			args{1,
+			&Callbacks{
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
+			}, args{1,
 				&envoy_api_v2.DiscoveryRequest{
 					Node:          &envoy_api_v2_core.Node{Id: "node1", Cluster: "cluster1"},
 					ResourceNames: []string{"string1", "string2"},

--- a/pkg/discoveryservice/xdss/v2/callbacks_test.go
+++ b/pkg/discoveryservice/xdss/v2/callbacks_test.go
@@ -16,10 +16,9 @@ package discoveryservice
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	"github.com/3scale-ops/marin3r/pkg/envoy"
+	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	cache_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -126,9 +125,8 @@ func TestCallbacks_OnStreamRequest(t *testing.T) {
 		{
 			"OnStreamRequest() NACK received",
 			&Callbacks{
-				OnError:       func(a, b, c string, d envoy.APIVersion) error { return nil },
-				SnapshotCache: fakeTestCache(),
-				Logger:        ctrl.Log,
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
 			},
 			args{1, &envoy_api_v2.DiscoveryRequest{
 				Node:          &envoy_api_v2_core.Node{Id: "node1", Cluster: "cluster1"},
@@ -137,36 +135,6 @@ func TestCallbacks_OnStreamRequest(t *testing.T) {
 				ErrorDetail:   &status.Status{Code: 0, Message: "xxxx"},
 			}},
 			false,
-		},
-		{
-			"OnStreamRequest() error",
-			&Callbacks{
-				OnError:       func(a, b, c string, d envoy.APIVersion) error { return nil },
-				SnapshotCache: fakeTestCache(),
-				Logger:        ctrl.Log,
-			},
-			args{1, &envoy_api_v2.DiscoveryRequest{
-				Node:          &envoy_api_v2_core.Node{Id: "node2", Cluster: "cluster1"},
-				ResourceNames: []string{"string1", "string2"},
-				TypeUrl:       "some-type",
-				ErrorDetail:   &status.Status{Code: 0, Message: "xxxx"},
-			}},
-			true,
-		},
-		{
-			"OnStreamRequest() error calling OnErrorFn",
-			&Callbacks{
-				OnError:       func(a, b, c string, d envoy.APIVersion) error { return fmt.Errorf("err") },
-				SnapshotCache: fakeTestCache(),
-				Logger:        ctrl.Log,
-			},
-			args{1, &envoy_api_v2.DiscoveryRequest{
-				Node:          &envoy_api_v2_core.Node{Id: "node1", Cluster: "cluster1"},
-				ResourceNames: []string{"string1", "string2"},
-				TypeUrl:       "some-type",
-				ErrorDetail:   &status.Status{Code: 0, Message: "xxxx"},
-			}},
-			true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/discoveryservice/xdss/v3/callbacks_test.go
+++ b/pkg/discoveryservice/xdss/v3/callbacks_test.go
@@ -16,10 +16,9 @@ package discoveryservice
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	"github.com/3scale-ops/marin3r/pkg/envoy"
+	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -127,9 +126,8 @@ func TestCallbacks_OnStreamRequest(t *testing.T) {
 		{
 			"OnStreamRequest() NACK received",
 			&Callbacks{
-				OnError:       func(a, b, c string, d envoy.APIVersion) error { return nil },
-				SnapshotCache: fakeTestCache(),
-				Logger:        ctrl.Log,
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
 			},
 			args{1, &envoy_service_discovery_v3.DiscoveryRequest{
 				Node:          &envoy_config_core_v3.Node{Id: "node1", Cluster: "cluster1"},
@@ -138,36 +136,6 @@ func TestCallbacks_OnStreamRequest(t *testing.T) {
 				ErrorDetail:   &status.Status{Code: 0, Message: "xxxx"},
 			}},
 			false,
-		},
-		{
-			"OnStreamRequest() error",
-			&Callbacks{
-				OnError:       func(a, b, c string, d envoy.APIVersion) error { return nil },
-				SnapshotCache: fakeTestCache(),
-				Logger:        ctrl.Log,
-			},
-			args{1, &envoy_service_discovery_v3.DiscoveryRequest{
-				Node:          &envoy_config_core_v3.Node{Id: "node2", Cluster: "cluster1"},
-				ResourceNames: []string{"string1", "string2"},
-				TypeUrl:       "some-type",
-				ErrorDetail:   &status.Status{Code: 0, Message: "xxxx"},
-			}},
-			true,
-		},
-		{
-			"OnStreamRequest() error calling OnErrorFn",
-			&Callbacks{
-				OnError:       func(a, b, c string, d envoy.APIVersion) error { return fmt.Errorf("err") },
-				SnapshotCache: fakeTestCache(),
-				Logger:        ctrl.Log,
-			},
-			args{1, &envoy_service_discovery_v3.DiscoveryRequest{
-				Node:          &envoy_config_core_v3.Node{Id: "node1", Cluster: "cluster1"},
-				ResourceNames: []string{"string1", "string2"},
-				TypeUrl:       "some-type",
-				ErrorDetail:   &status.Status{Code: 0, Message: "xxxx"},
-			}},
-			true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/discoveryservice/xdss/v3/callbacks_test.go
+++ b/pkg/discoveryservice/xdss/v3/callbacks_test.go
@@ -91,7 +91,10 @@ func TestCallbacks_OnStreamClosed(t *testing.T) {
 	}{
 		{
 			"OnStreamClosed()",
-			&Callbacks{Logger: ctrl.Log},
+			&Callbacks{
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
+			},
 			args{1},
 		}}
 	for _, tt := range tests {
@@ -114,7 +117,10 @@ func TestCallbacks_OnStreamRequest(t *testing.T) {
 	}{
 		{
 			"OnStreamRequest()",
-			&Callbacks{Logger: ctrl.Log},
+			&Callbacks{
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
+			},
 			args{1, &envoy_service_discovery_v3.DiscoveryRequest{
 				Node:          &envoy_config_core_v3.Node{Id: "node1", Cluster: "cluster1"},
 				ResourceNames: []string{"string1", "string2"},
@@ -160,7 +166,10 @@ func TestCallbacks_OnStreamResponse(t *testing.T) {
 	}{
 		{
 			"OnStreamResponse()",
-			&Callbacks{Logger: ctrl.Log},
+			&Callbacks{
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
+			},
 			args{1,
 				&envoy_service_discovery_v3.DiscoveryRequest{
 					Node:          &envoy_config_core_v3.Node{Id: "node1", Cluster: "cluster1"},
@@ -178,7 +187,10 @@ func TestCallbacks_OnStreamResponse(t *testing.T) {
 		},
 		{
 			"OnStreamResponse() special treatment of secret resources",
-			&Callbacks{Logger: ctrl.Log},
+			&Callbacks{
+				Stats:  stats.New(),
+				Logger: ctrl.Log,
+			},
 			args{1,
 				&envoy_service_discovery_v3.DiscoveryRequest{
 					Node:          &envoy_config_core_v3.Node{Id: "node1", Cluster: "cluster1"},

--- a/pkg/envoy/resources/type_urls.go
+++ b/pkg/envoy/resources/type_urls.go
@@ -1,0 +1,14 @@
+package envoy
+
+import (
+	"github.com/3scale-ops/marin3r/pkg/envoy"
+	envoy_resources_v2 "github.com/3scale-ops/marin3r/pkg/envoy/resources/v2"
+	envoy_resources_v3 "github.com/3scale-ops/marin3r/pkg/envoy/resources/v3"
+)
+
+func TypeURL(rType envoy.Type, version envoy.APIVersion) string {
+	if version == envoy.APIv2 {
+		return envoy_resources_v2.Mappings()[rType]
+	}
+	return envoy_resources_v3.Mappings()[rType]
+}

--- a/pkg/reconcilers/marin3r/envoyconfig/reconcile_revisions.go
+++ b/pkg/reconcilers/marin3r/envoyconfig/reconcile_revisions.go
@@ -142,12 +142,11 @@ func (r *RevisionReconciler) Reconcile() (ctrl.Result, error) {
 
 	shouldBeTrue, shouldBeFalse := r.isRevisionPublishedConditionReconciled(r.PublishedVersion())
 
-	if shouldBeFalse != nil {
-		for _, ecr := range shouldBeFalse {
-			if err := r.client.Status().Update(r.ctx, &ecr); err != nil {
-				log.Error(err, "unable to update revision", "Phase", "UnpublishOldRevisions", "Name/Namespace", util.ObjectKey(&ecr))
-				return ctrl.Result{}, err
-			}
+	for _, ecr := range shouldBeFalse {
+
+		if err := r.client.Status().Update(r.ctx, &ecr); err != nil {
+			log.Error(err, "unable to update revision", "Phase", "UnpublishOldRevisions", "Name/Namespace", util.ObjectKey(&ecr))
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -160,14 +159,12 @@ func (r *RevisionReconciler) Reconcile() (ctrl.Result, error) {
 	}
 
 	shouldBeDeleted := r.isRevisionRetentionReconciled(maxRevisions)
-	if shouldBeDeleted != nil {
-		for _, ecr := range shouldBeDeleted {
-			if err := r.client.Delete(r.ctx, &ecr); err != nil {
-				log.Error(err, "unable to delete revision", "Phase", "ApplyRevisionRetention", "Name/Namespace", util.ObjectKey(&ecr))
-				return ctrl.Result{}, err
-			}
-			log.Info("deleted old EnvoyConfigRevision", "Namespace/Name", util.ObjectKey(&ecr))
+	for _, ecr := range shouldBeDeleted {
+		if err := r.client.Delete(r.ctx, &ecr); err != nil {
+			log.Error(err, "unable to delete revision", "Phase", "ApplyRevisionRetention", "Name/Namespace", util.ObjectKey(&ecr))
+			return ctrl.Result{}, err
 		}
+		log.Info("deleted old EnvoyConfigRevision", "Namespace/Name", util.ObjectKey(&ecr))
 	}
 
 	log.Info(fmt.Sprintf("CacheState is %s after revision reconcile", cacheState))
@@ -212,7 +209,6 @@ func (r *RevisionReconciler) isRevisionPublishedConditionReconciled(versionToPub
 
 	var shouldBeTrue *marin3rv1alpha1.EnvoyConfigRevision = nil
 	var shouldBeFalse []marin3rv1alpha1.EnvoyConfigRevision = []marin3rv1alpha1.EnvoyConfigRevision{}
-
 	for _, ecr := range r.revisionList.Items {
 
 		if ecr.Spec.Version != versionToPublish && ecr.Status.Conditions.IsTrueFor(marin3rv1alpha1.RevisionPublishedCondition) {

--- a/pkg/reconcilers/marin3r/envoyconfig/reconcile_revisions.go
+++ b/pkg/reconcilers/marin3r/envoyconfig/reconcile_revisions.go
@@ -226,7 +226,7 @@ func (r *RevisionReconciler) isRevisionPublishedConditionReconciled(versionToPub
 				Reason:  status.ConditionReason("VersionPublished"),
 				Message: fmt.Sprintf("Version '%s' has been published", versionToPublish),
 			})
-			shouldBeTrue = &ecr
+			shouldBeTrue = ecr.DeepCopy()
 		}
 	}
 

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/cache.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/cache.go
@@ -54,8 +54,6 @@ func (r *CacheReconciler) Reconcile(req types.NamespacedName, resources *marin3r
 			return nil, err
 		}
 
-	} else {
-		r.logger.V(1).Info("Snapshot has not changed, skipping writing to xDS cache", "NodeID", nodeID)
 	}
 
 	return &marin3rv1alpha1.VersionTracker{

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/finalize.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/finalize.go
@@ -3,12 +3,15 @@ package reconcilers
 import (
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	xdss "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss"
+	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	"github.com/go-logr/logr"
 )
 
 // CleanupLogic executes finalization code for EnvoyConfigRevision resources
-func CleanupLogic(ecr *marin3rv1alpha1.EnvoyConfigRevision, xdssCache xdss.Cache, log logr.Logger) {
+func CleanupLogic(ecr *marin3rv1alpha1.EnvoyConfigRevision, xdssCache xdss.Cache, discoveryStats *stats.Stats, log logr.Logger) {
+
 	if ecr.Status.Conditions.IsTrueFor(marin3rv1alpha1.RevisionPublishedCondition) {
+		discoveryStats.DeleteKeysByFilter(ecr.Spec.NodeID)
 		xdssCache.ClearSnapshot(ecr.Spec.NodeID)
 		log.Info("Successfully cleared xDS server cache", "XDSS", string(ecr.GetEnvoyAPIVersion()), "NodeID", ecr.Spec.NodeID)
 	}

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/status_test.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/status_test.go
@@ -5,10 +5,15 @@ import (
 
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	xdss "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss"
+	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	xdss_v3 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v3"
+	"github.com/3scale-ops/marin3r/pkg/envoy"
+	"github.com/davecgh/go-spew/spew"
 	cache_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/operator-framework/operator-lib/status"
+	"github.com/patrickmn/go-cache"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -35,6 +40,7 @@ func TestIsStatusReconciled(t *testing.T) {
 		envoyConfigRevisionFactory func() *marin3rv1alpha1.EnvoyConfigRevision
 		versionTrackerFactory      func() *marin3rv1alpha1.VersionTracker
 		xdssCacheFactory           func() xdss.Cache
+		dStats                     func() *stats.Stats
 	}
 	tests := []struct {
 		name string
@@ -68,6 +74,7 @@ func TestIsStatusReconciled(t *testing.T) {
 					}
 				},
 				xdssCacheFactory: testCacheGenerator("test", "xxxx"),
+				dStats:           stats.New,
 			},
 			want: false,
 		},
@@ -117,6 +124,7 @@ func TestIsStatusReconciled(t *testing.T) {
 					}
 				},
 				xdssCacheFactory: testCacheGenerator("test", "xxxx"),
+				dStats:           stats.New,
 			},
 			want: true,
 		},
@@ -141,6 +149,7 @@ func TestIsStatusReconciled(t *testing.T) {
 				},
 				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return nil },
 				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
+				dStats:                stats.New,
 			},
 			want: false,
 		},
@@ -164,6 +173,68 @@ func TestIsStatusReconciled(t *testing.T) {
 				},
 				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return nil },
 				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
+				dStats:                stats.New,
+			},
+			want: true,
+		},
+		{
+			name: "Reported failed, needs tainted condition",
+			args: args{
+				envoyConfigRevisionFactory: func() *marin3rv1alpha1.EnvoyConfigRevision {
+					return &marin3rv1alpha1.EnvoyConfigRevision{
+						Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
+							Version:  "xxxx",
+							NodeID:   "test",
+							EnvoyAPI: pointer.StringPtr(envoy.APIv3.String()),
+						},
+						Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
+							ProvidesVersions: &marin3rv1alpha1.VersionTracker{Endpoints: "aaaa"},
+						},
+					}
+				},
+				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
+				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return &marin3rv1alpha1.VersionTracker{Endpoints: "aaaa"} },
+				dStats: func() *stats.Stats {
+					return stats.NewWithItems(map[string]cache.Item{
+						"test:" + resource_v3.EndpointType + ":*:pod-aaaa:request_counter:stream_1": {Object: int64(2), Expiration: int64(0)},
+						"test:" + resource_v3.EndpointType + ":aaaa:pod-aaaa:nack_counter":          {Object: int64(1), Expiration: int64(0)},
+					})
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Reported failed, status already up to date",
+			args: args{
+				envoyConfigRevisionFactory: func() *marin3rv1alpha1.EnvoyConfigRevision {
+					return &marin3rv1alpha1.EnvoyConfigRevision{
+						Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
+							Version:  "xxxx",
+							NodeID:   "test",
+							EnvoyAPI: pointer.StringPtr(envoy.APIv3.String()),
+						},
+						Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
+							ProvidesVersions: &marin3rv1alpha1.VersionTracker{Endpoints: "aaaa"},
+							Tainted:          pointer.BoolPtr(true),
+							Conditions: status.Conditions{
+								{
+									Type:    marin3rv1alpha1.RevisionTaintedCondition,
+									Status:  corev1.ConditionTrue,
+									Reason:  "ResourcesFailing",
+									Message: "EnvoyConfigRevision resources are being rejected by more than 100% of the Envoy clients",
+								},
+							},
+						},
+					}
+				},
+				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
+				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return &marin3rv1alpha1.VersionTracker{Endpoints: "aaaa"} },
+				dStats: func() *stats.Stats {
+					return stats.NewWithItems(map[string]cache.Item{
+						"test:" + resource_v3.EndpointType + ":*:pod-aaaa:request_counter:stream_1": {Object: int64(2), Expiration: int64(0)},
+						"test:" + resource_v3.EndpointType + ":aaaa:pod-aaaa:nack_counter":          {Object: int64(1), Expiration: int64(0)},
+					})
+				},
 			},
 			want: true,
 		},
@@ -185,6 +256,7 @@ func TestIsStatusReconciled(t *testing.T) {
 				},
 				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return nil },
 				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
+				dStats:                stats.New,
 			},
 			want: false,
 		},
@@ -207,6 +279,7 @@ func TestIsStatusReconciled(t *testing.T) {
 				},
 				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return nil },
 				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
+				dStats:                stats.New,
 			},
 			want: true,
 		},
@@ -214,7 +287,8 @@ func TestIsStatusReconciled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ecr := tt.args.envoyConfigRevisionFactory()
-			if got := IsStatusReconciled(ecr, tt.args.versionTrackerFactory(), tt.args.xdssCacheFactory()); got != tt.want {
+			if got := IsStatusReconciled(ecr, tt.args.versionTrackerFactory(), tt.args.xdssCacheFactory(), tt.args.dStats()); got != tt.want {
+				spew.Dump(ecr.Status)
 				t.Errorf("IsStatusReconciled() = %v, want %v", got, tt.want)
 			}
 		})
@@ -279,6 +353,140 @@ func Test_calculateResourcesInSyncCondition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := calculateResourcesInSyncCondition(tt.args.envoyConfigRevisionFactory(), tt.args.xdssCacheFactory()); got.Status != tt.want {
 				t.Errorf("calculateResourcesInSyncCondition() = %v, want %v", got.Status, tt.want)
+			}
+		})
+	}
+}
+
+func Test_calculateRevisionTaintedCondition(t *testing.T) {
+	type args struct {
+		ecr        *marin3rv1alpha1.EnvoyConfigRevision
+		vt         *marin3rv1alpha1.VersionTracker
+		dStats     *stats.Stats
+		thresshold float64
+	}
+	tests := []struct {
+		name string
+		args args
+		want corev1.ConditionStatus
+	}{
+		{
+			name: "All endpoints fail, return taint",
+			args: args{
+				ecr: &marin3rv1alpha1.EnvoyConfigRevision{
+					ObjectMeta: metav1.ObjectMeta{Name: "ecr", Namespace: "test"},
+					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
+						NodeID:   "node",
+						EnvoyAPI: pointer.StringPtr(envoy.APIv3.String()),
+					},
+				},
+				vt: &marin3rv1alpha1.VersionTracker{
+					Endpoints: "xxxx",
+					Clusters:  "",
+					Routes:    "",
+					Listeners: "",
+					Secrets:   "",
+					Runtimes:  "",
+				},
+				dStats: stats.NewWithItems(map[string]cache.Item{
+					"node:" + resource_v3.EndpointType + ":*:pod-bbbb:request_counter:stream_2": {Object: int64(5), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":*:pod-cccc:request_counter:stream_3": {Object: int64(1), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":*:pod-dddd:request_counter:stream_4": {Object: int64(1), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":*:pod-aaaa:request_counter:stream_1": {Object: int64(2), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":xxxx:pod-aaaa:nack_counter":          {Object: int64(1), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":xxxx:pod-bbbb:nack_counter":          {Object: int64(10), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":xxxx:pod-cccc:nack_counter":          {Object: int64(10), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":xxxx:pod-dddd:nack_counter":          {Object: int64(10), Expiration: int64(0)},
+				}),
+				thresshold: 1,
+			},
+			want: corev1.ConditionTrue,
+		},
+		{
+			name: "Half of endpoints fail, return taint",
+			args: args{
+				ecr: &marin3rv1alpha1.EnvoyConfigRevision{
+					ObjectMeta: metav1.ObjectMeta{Name: "ecr", Namespace: "test"},
+					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
+						NodeID:   "node",
+						EnvoyAPI: pointer.StringPtr(envoy.APIv3.String()),
+					},
+				},
+				vt: &marin3rv1alpha1.VersionTracker{
+					Endpoints: "xxxx",
+					Clusters:  "",
+					Routes:    "",
+					Listeners: "",
+					Secrets:   "",
+					Runtimes:  "",
+				},
+				dStats: stats.NewWithItems(map[string]cache.Item{
+					"node:" + resource_v3.EndpointType + ":*:pod-bbbb:request_counter:stream_2": {Object: int64(5), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":*:pod-cccc:request_counter:stream_3": {Object: int64(1), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":*:pod-dddd:request_counter:stream_4": {Object: int64(1), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":*:pod-aaaa:request_counter:stream_1": {Object: int64(2), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":xxxx:pod-aaaa:nack_counter":          {Object: int64(1), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":xxxx:pod-bbbb:nack_counter":          {Object: int64(10), Expiration: int64(0)},
+				}),
+				thresshold: 0.5,
+			},
+			want: corev1.ConditionTrue,
+		},
+		{
+			name: "Less than half of endpoints fail, return nil",
+			args: args{
+				ecr: &marin3rv1alpha1.EnvoyConfigRevision{
+					ObjectMeta: metav1.ObjectMeta{Name: "ecr", Namespace: "test"},
+					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
+						NodeID:   "node",
+						EnvoyAPI: pointer.StringPtr(envoy.APIv3.String()),
+					},
+				},
+				vt: &marin3rv1alpha1.VersionTracker{
+					Endpoints: "xxxx",
+					Clusters:  "",
+					Routes:    "",
+					Listeners: "",
+					Secrets:   "",
+					Runtimes:  "",
+				},
+				dStats: stats.NewWithItems(map[string]cache.Item{
+					"node:" + resource_v3.EndpointType + ":*:pod-bbbb:request_counter:stream_2": {Object: int64(5), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":*:pod-cccc:request_counter:stream_3": {Object: int64(1), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":*:pod-dddd:request_counter:stream_4": {Object: int64(1), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":*:pod-aaaa:request_counter:stream_1": {Object: int64(2), Expiration: int64(0)},
+					"node:" + resource_v3.EndpointType + ":xxxx:pod-aaaa:nack_counter":          {Object: int64(1), Expiration: int64(0)},
+				}),
+				thresshold: 0.5,
+			},
+			want: corev1.ConditionFalse,
+		},
+		{
+			name: "No data, return nil",
+			args: args{
+				ecr: &marin3rv1alpha1.EnvoyConfigRevision{
+					ObjectMeta: metav1.ObjectMeta{Name: "ecr", Namespace: "test"},
+					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
+						NodeID:   "node",
+						EnvoyAPI: pointer.StringPtr(envoy.APIv3.String()),
+					},
+				}, vt: &marin3rv1alpha1.VersionTracker{},
+				dStats:     stats.NewWithItems(map[string]cache.Item{}),
+				thresshold: 1,
+			},
+			want: corev1.ConditionFalse,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateRevisionTaintedCondition(tt.args.ecr, tt.args.vt, tt.args.dStats, tt.args.thresshold)
+			if tt.want == corev1.ConditionFalse && got != nil {
+				t.Errorf("calculateRevisionTaintedCondition() = %v, want %v", got, tt.want)
+				return
+			}
+			if tt.want == corev1.ConditionTrue && got == nil {
+				t.Errorf("calculateRevisionTaintedCondition() = %v, want %v", got, tt.want)
+				return
 			}
 		})
 	}

--- a/pkg/util/backoff/backoff.go
+++ b/pkg/util/backoff/backoff.go
@@ -1,0 +1,38 @@
+package backoff
+
+import (
+	"math/rand"
+	"time"
+)
+
+// BackoffPolicy implements a backoff policy, randomizing its delays
+// and saturating at the final value in Millis.
+type BackoffPolicy struct {
+	Millis []int
+}
+
+// Default is a backoff policy ranging up to 5 seconds.
+var Default = BackoffPolicy{
+	[]int{0, 10, 10, 100, 100, 500, 500, 3000, 3000, 5000},
+}
+
+// Duration returns the time duration of the n'th wait cycle in a
+// backoff policy. This is b.Millis[n], randomized to avoid thundering
+// herds.
+func (b BackoffPolicy) Duration(n int) time.Duration {
+	if n >= len(b.Millis) {
+		n = len(b.Millis) - 1
+	}
+
+	return time.Duration(jitter(b.Millis[n])) * time.Millisecond
+}
+
+// jitter returns a random integer uniformly distributed in the range
+// [0.5 * millis .. 1.5 * millis]
+func jitter(millis int) int {
+	if millis == 0 {
+		return 0
+	}
+
+	return millis/2 + rand.Intn(millis)
+}

--- a/pkg/util/k8s/util.go
+++ b/pkg/util/k8s/util.go
@@ -1,0 +1,14 @@
+package k8sutil
+
+import "github.com/operator-framework/operator-lib/status"
+
+func ConditionsEqual(a, b *status.Condition) bool {
+	if a == nil && b == nil {
+		return true
+	}
+
+	if a != nil && b != nil && a.Type == b.Type && a.Reason == b.Reason && a.Message == b.Message {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This PR includes the following:

* Fixed a bug affecting reconcile of EnvoyConfigRevision status: d7687ea600d0293bb62e1146cd195e3e5d631f87
* Implemented a mechanism to internally store statistics related to the xDS protocol messages interchanged between clients and the discovery service: 24e5b59e4636612f11adacf9b7ed5a471d2cc9af
* Reimplemented the self-healing using the internal xDS stats: 1b17645cd666ac48be2d399189b56fe483b9e8d4
* Implemented a backoff algorithm to avoid overloading the envoy clients with retries from the discovery service: 86d1b6dc8ff8aa8f3d19040cebf757f177a37269

/kind feature
/priority important-soon
/assign