### PR TITLE
Fix: enable multinamespaced mode for the webhook

### DIFF
--- a/config/olm/kustomization.yaml
+++ b/config/olm/kustomization.yaml
@@ -70,6 +70,13 @@ patches:
       - --tls-dir=/apiserver.local.config/certificates
       - --tls-cert-name=apiserver.crt
       - --tls-key-name=apiserver.key
+    - op: add
+      path: /spec/template/spec/containers/0/env
+      value:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['olm.targetNamespaces']
   target:
     group: apps
     kind: Deployment

--- a/config/webhook/deployment.yaml
+++ b/config/webhook/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       containers:
         - command:
             - /manager
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
           args:
             - webhook
             - --tls-dir=/tmp/k8s-webhook-server/serving-certs


### PR DESCRIPTION
Since now the bootstrap config for the envoy pods is generated by an
init container, the webhook needs to inject the address of the discovery
service in the Pod. To do so it inspects the DiscoveryService resources
present in the Pod's namespace. This was failing for the multinamespaced
OLM install mode as the code to manage this was missing from the
webhook.

/kind bug
/priority important-soon
/assign