### PR TITLE
Add a name to the V3 file-based SDS tls secret response (second try)

### DIFF
--- a/pkg/envoy/bootstrap/v3/bootstrap.go
+++ b/pkg/envoy/bootstrap/v3/bootstrap.go
@@ -40,6 +40,7 @@ func (c *Config) GenerateStatic() (string, error) {
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
 			TlsCertificateSdsSecretConfigs: []*envoy_extensions_transport_sockets_tls_v3.SdsSecretConfig{
 				{
+					Name: "xds_client_certificate",
 					SdsConfig: &envoy_config_core_v3.ConfigSource{
 						ConfigSourceSpecifier: &envoy_config_core_v3.ConfigSource_Path{
 							Path: c.Options.SdsConfigSourcePath,

--- a/pkg/envoy/bootstrap/v3/bootstrap_test.go
+++ b/pkg/envoy/bootstrap/v3/bootstrap_test.go
@@ -29,7 +29,7 @@ func TestConfig_GenerateStatic(t *testing.T) {
 					Metadata:                    map[string]string{"key1": "value1", "key2": "value2"},
 				},
 			},
-			want:    `{"node":{"id":"some-id","cluster":"some-cluster","metadata":{"key1":"value1","key2":"value2"}},"static_resources":{"clusters":[{"name":"xds_cluster","type":"STRICT_DNS","connect_timeout":"1s","load_assignment":{"cluster_name":"xds_cluster","endpoints":[{"lb_endpoints":[{"endpoint":{"address":{"socket_address":{"address":"localhost","port_value":10000}}}}]}]},"http2_protocol_options":{},"transport_socket":{"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"tls_certificate_sds_secret_configs":[{"sds_config":{"path":"/sds-config-source.json"}}]}}}}]},"dynamic_resources":{"lds_config":{"ads":{},"resource_api_version":"V3"},"cds_config":{"ads":{},"resource_api_version":"V3"},"ads_config":{"api_type":"GRPC","transport_api_version":"V3","grpc_services":[{"envoy_grpc":{"cluster_name":"xds_cluster"}}]}},"layered_runtime":{"layers":[{"name":"runtime","rtds_layer":{"name":"runtime","rtds_config":{"ads":{},"resource_api_version":"V3"}}}]},"admin":{"access_log_path":"/dev/null","address":{"socket_address":{"address":"0.0.0.0","port_value":9001}}}}`,
+			want:    `{"node":{"id":"some-id","cluster":"some-cluster","metadata":{"key1":"value1","key2":"value2"}},"static_resources":{"clusters":[{"name":"xds_cluster","type":"STRICT_DNS","connect_timeout":"1s","load_assignment":{"cluster_name":"xds_cluster","endpoints":[{"lb_endpoints":[{"endpoint":{"address":{"socket_address":{"address":"localhost","port_value":10000}}}}]}]},"http2_protocol_options":{},"transport_socket":{"name":"envoy.transport_sockets.tls","typed_config":{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext","common_tls_context":{"tls_certificate_sds_secret_configs":[{"name":"xds_client_certificate","sds_config":{"path":"/sds-config-source.json"}}]}}}}]},"dynamic_resources":{"lds_config":{"ads":{},"resource_api_version":"V3"},"cds_config":{"ads":{},"resource_api_version":"V3"},"ads_config":{"api_type":"GRPC","transport_api_version":"V3","grpc_services":[{"envoy_grpc":{"cluster_name":"xds_cluster"}}]}},"layered_runtime":{"layers":[{"name":"runtime","rtds_layer":{"name":"runtime","rtds_config":{"ads":{},"resource_api_version":"V3"}}}]},"admin":{"access_log_path":"/dev/null","address":{"socket_address":{"address":"0.0.0.0","port_value":9001}}}}`,
 			wantErr: false,
 		},
 	}
@@ -66,7 +66,7 @@ func TestConfig_GenerateSdsResources(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"tls_certificate_sds_secret.json": `{"resources":[{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret","tls_certificate":{"certificate_chain":{"filename":"/tls.crt"},"private_key":{"filename":"/tls.key"}}}]}`,
+				"tls_certificate_sds_secret.json": `{"resources":[{"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret","name":"xds_client_certificate","tls_certificate":{"certificate_chain":{"filename":"/tls.crt"},"private_key":{"filename":"/tls.key"}}}]}`,
 			},
 			wantErr: false,
 		},

--- a/pkg/envoy/resources/v3/resources.go
+++ b/pkg/envoy/resources/v3/resources.go
@@ -66,6 +66,7 @@ func (g Generator) NewSecret(name, privateKey, certificateChain string) envoy.Re
 func (g Generator) NewSecretFromPath(name, certificateChainPath, privateKeyPath string) envoy.Resource {
 
 	return &envoy_extensions_transport_sockets_tls_v3.Secret{
+		Name: name,
 		Type: &envoy_extensions_transport_sockets_tls_v3.Secret_TlsCertificate{
 			TlsCertificate: &envoy_extensions_transport_sockets_tls_v3.TlsCertificate{
 				CertificateChain: &envoy_config_core_v3.DataSource{


### PR DESCRIPTION
This is a trivial change but will hopefully save somebody some time when they decide to upgrade to Envoy v0.17.x.

I made a previous try at this in PR #88 but that was bad. This is a second try.

This applies only to the V3 protocol.

This impacts the tls_certificate_sds_secret.json config file, not the response sent over the wire to xDS clients.

Marin3r generates this file and adds it to a k8s secret which is
mounted into Envoy pods. Envoy uses this file to retrieve the
bootstrap certs that allow it to talk to Marin3r over TLS. If there's
no "name" field then Envoy v0.17.0 can't process the cert, although
older Envoy versions can.

[2021-02-18 23:20:51.419][1][critical][main] [source/server/server.cc:109] error initializing configuration '/etc/envoy/bootstrap/config.json': Proto constraint validation failed (UpstreamTlsContextValidationError.CommonTlsContext: ["embe
dded message failed validation"] | caused by CommonTlsContextValidationError.TlsCertificateSdsSecretConfigs[i]: ["embedded message failed validation"] | caused by SdsSecretConfigValidationError.Name: ["value length must be at least " '\x0
1' " runes"]): common_tls_context {
  tls_certificate_sds_secret_configs {
    sds_config {
      path: "/etc/envoy/bootstrap/tls_certificate_sds_secret.json"
    }
  }
}

[2021-02-18 23:20:51.419][1][info][main] [source/server/server.cc:782] exiting
Proto constraint validation failed (UpstreamTlsContextValidationError.CommonTlsContext: ["embedded message failed validation"] | caused by CommonTlsContextValidationError.TlsCertificateSdsSecretConfigs[i]: ["embedded message failed valida
tion"] | caused by SdsSecretConfigValidationError.Name: ["value length must be at least " '\x01' " runes"]): common_tls_context {
  tls_certificate_sds_secret_configs {
    sds_config {
      path: "/etc/envoy/bootstrap/tls_certificate_sds_secret.json"
    }
  }
}

Thank you @roivaz for pointing me to this fix and for your patience with my previous PR.

/closes #88 
