### PR TITLE
fix/deleted-resources-reconcile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,4 @@ require (
 	sigs.k8s.io/controller-runtime v0.7.2
 )
 
-replace github.com/redhat-cop/operator-utils v1.1.2 => github.com/roivaz/operator-utils v1.1.3-0.20210518155433-82fe9bc469ab
+replace github.com/redhat-cop/operator-utils v1.1.2 => github.com/roivaz/operator-utils v1.1.3-0.20210601154758-2d8356946ef8

--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,8 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/roivaz/operator-utils v1.1.3-0.20210518155433-82fe9bc469ab h1:mUgJ+5EjRr+0oTGxkn9mVi3AzaboPSQ0Y2ARLVn2tLE=
-github.com/roivaz/operator-utils v1.1.3-0.20210518155433-82fe9bc469ab/go.mod h1:Hu6OKop6iQfga0Hwrqv/03CQgpkcp55qwjMh9Gi0Iyk=
+github.com/roivaz/operator-utils v1.1.3-0.20210601154758-2d8356946ef8 h1:Wp9dM8RjUwLKITifq959pvrYXmXqNVO1hDNe5M9heF8=
+github.com/roivaz/operator-utils v1.1.3-0.20210601154758-2d8356946ef8/go.mod h1:Hu6OKop6iQfga0Hwrqv/03CQgpkcp55qwjMh9Gi0Iyk=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=


### PR DESCRIPTION
Fixes a bug in the reconcile of deleted resources in redhat-cop/operator-utils module: https://github.com/roivaz/operator-utils/commit/2d8356946ef821c54da91ed5796cec6f4f0d3c56

/kind bug
/priority important-soon
/assign