### PR TITLE
Add documentation about the operator release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ bundle-build:
 
 prepare-alpha-release: bump-release generate fmt vet manifests bundle
 
-prepare-release: bump-release generate fmt vet manifests bundle refdocs
+prepare-stable-release: bump-release generate fmt vet manifests bundle refdocs
 	$(MAKE) bundle CHANNELS=alpha,stable DEFAULT_CHANNEL=alpha
 
 bump-release:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Lighweight, CRD based Envoy control plane for Kubernetes:
   - [**Sidecar injection**](#sidecar-injection)
   - [**Operator**](#operator)
 - [**Development**](#development)
+- [**Release**](#release)
 
 ## **Overview**
 
@@ -593,3 +594,7 @@ For an in-depth look at how MARIN3R works, check the [design docs](/docs/design)
 ## **Development**
 
 You can find development documentation [here](/docs/development/README.md).
+
+## **Release**
+
+You can find release process documentation [here](/docs/release.md).

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,19 @@
+# Release
+
+* Update Makefile variable `VERSION` to the appropiate release version. Allowed formats:
+  * alpha: `VERSION ?= 0.3.0-alpha.12`
+  * stable: `VERSION ?= 0.3.0`
+
+## Alpha
+* If it is an **alpha** release, execute the following target to create appropiate `alpha` bundle files:
+```bash
+make prepare-alpha-release
+```
+* Then you can manually execute opeator, bundle and catalog build/push.
+
+## Stable
+* But if it is an **stable** release, execute the following target to create appropiate `alpha` and `stable` bundle files:
+```bash
+make prepare-stable-release
+```
+* Then open a [Pull Request](https://github.com/3scale-ops/marin3r/pulls), and a GitHub Action will automatically detect if it is new release or not, in order to create it by building/pushing new operator, bundle and catalog images, as well as creating a GitHub release draft.


### PR DESCRIPTION
- Added documentation about release process of stable/alpha releases
- To avoid accidental stable releases creation when you want to do an alpha release, the prepare stable  target has been renamed
- Docs taken from [prometheus-exporter-operator release doc](https://github.com/3scale-ops/prometheus-exporter-operator/blob/main/docs/prometheus-exporter-crd-reference.md), so right now all our 3 operators ([prometheus-exporter-operator](https://github.com/3scale-ops/prometheus-exporter-operator), [marin3r](https://github.com/3scale-ops/marin3r) and [saas-operator](https://github.com/3scale-ops/saas-operator) ) use the exactly same release process (easier maintenance using all of them the same).

/kind documentation
/priority important-soon
/assign