### PR TITLE
Print the config generated by the init-manager for easy troubleshooting

### DIFF
--- a/cmd/initmanager.go
+++ b/cmd/initmanager.go
@@ -145,7 +145,8 @@ func runInitManager(cmd *cobra.Command, args []string) {
 		setupLog.Error(err, "")
 		os.Exit(-1)
 	}
-	setupLog.Info(fmt.Sprintf("Created %s", initmgrConfigPath))
+	setupLog.Info("Config succesfully generated", "config", config)
+	setupLog.Info(fmt.Sprintf("Created file '%s' with config", initmgrConfigPath))
 
 	// Write the resource files
 	for file, contents := range sdsResources {
@@ -162,7 +163,8 @@ func runInitManager(cmd *cobra.Command, args []string) {
 			os.Exit(-1)
 		}
 		rf.Close()
-		setupLog.Info(fmt.Sprintf("Created %s/%s", initmgrSdsConfigSourcePath, file))
+		setupLog.Info("Config succesfully generated", "config", contents)
+		setupLog.Info(fmt.Sprintf("Created file '%s/%s' with config", initmgrSdsConfigSourcePath, file))
 	}
 
 }


### PR DESCRIPTION
Just a quality of life improvement so you can check the generated config directly in the container logs. There is no other way to check the generated config as we are now using an empty base image that does not have a shell to actually inspect the file inside the container.

/kind feature
/priority important-longterm
/assign