### PR TITLE
Rename field 'podAffinity' to just 'affinity' in EnvoyDeployment resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 # Project name
 NAME := marin3r
 # Current Operator version
-VERSION ?= 0.8.0-alpha.10
+VERSION ?= 0.8.0-alpha.15
 # Default bundle image tag
 BUNDLE_IMG ?= quay.io/3scale/marin3r-bundle:v$(VERSION)
 INDEX_IMG ?= quay.io/3scale/marin3r-catalog:latest

--- a/apis/operator.marin3r/v1alpha1/envoydeployment_types.go
+++ b/apis/operator.marin3r/v1alpha1/envoydeployment_types.go
@@ -117,7 +117,7 @@ type EnvoyDeploymentSpec struct {
 	// Affinity configuration for the envoy pods
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
-	PodAffinity *corev1.Affinity `json:"podAffinity,omitempty"`
+	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 	// Configures PodDisruptionBudget for the envoy Pods
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
@@ -197,8 +197,8 @@ func (ed *EnvoyDeployment) ReadinessProbe() ProbeSpec {
 	return *ed.Spec.ReadinessProbe
 }
 
-func (ed *EnvoyDeployment) PodAffinity() *corev1.Affinity {
-	return ed.Spec.PodAffinity
+func (ed *EnvoyDeployment) Affinity() *corev1.Affinity {
+	return ed.Spec.Affinity
 }
 
 func (ed *EnvoyDeployment) PodDisruptionBudget() PodDisruptionBudgetSpec {

--- a/apis/operator.marin3r/v1alpha1/envoydeployment_types_test.go
+++ b/apis/operator.marin3r/v1alpha1/envoydeployment_types_test.go
@@ -348,7 +348,7 @@ func TestEnvoyDeployment_PodAffinity(t *testing.T) {
 	}{
 		{"Returns value",
 			func() *EnvoyDeployment {
-				return &EnvoyDeployment{Spec: EnvoyDeploymentSpec{PodAffinity: &corev1.Affinity{}}}
+				return &EnvoyDeployment{Spec: EnvoyDeploymentSpec{Affinity: &corev1.Affinity{}}}
 			},
 			&corev1.Affinity{},
 		},
@@ -356,7 +356,7 @@ func TestEnvoyDeployment_PodAffinity(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.testName, func(subT *testing.T) {
-			receivedResult := tc.envoyDeploymentFactory().PodAffinity()
+			receivedResult := tc.envoyDeploymentFactory().Affinity()
 			if !equality.Semantic.DeepEqual(tc.expectedResult, receivedResult) {
 				subT.Errorf("Expected result differs: Expected: %v, Received: %v", tc.expectedResult, receivedResult)
 			}

--- a/apis/operator.marin3r/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/operator.marin3r/v1alpha1/zz_generated.deepcopy.go
@@ -539,8 +539,8 @@ func (in *EnvoyDeploymentSpec) DeepCopyInto(out *EnvoyDeploymentSpec) {
 		*out = new(ProbeSpec)
 		**out = **in
 	}
-	if in.PodAffinity != nil {
-		in, out := &in.PodAffinity, &out.PodAffinity
+	if in.Affinity != nil {
+		in, out := &in.Affinity, &out.Affinity
 		*out = new(v1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}

--- a/bundle/manifests/marin3r.3scale.net_envoyconfigrevisions.yaml
+++ b/bundle/manifests/marin3r.3scale.net_envoyconfigrevisions.yaml
@@ -216,6 +216,22 @@ spec:
                 description: LastPublishedAt indicates the last time this config review transitioned to published
                 format: date-time
                 type: string
+              providesVersions:
+                description: ProvidesVersions keeps track of the version that this revision publishes in the xDS server for each resource type
+                properties:
+                  clusters:
+                    type: string
+                  endpoints:
+                    type: string
+                  listeners:
+                    type: string
+                  routes:
+                    type: string
+                  runtimes:
+                    type: string
+                  secrets:
+                    type: string
+                type: object
               published:
                 description: Published signals if the EnvoyConfigRevision is the one currently published in the xds server cache
                 type: boolean

--- a/bundle/manifests/marin3r.clusterserviceversion.yaml
+++ b/bundle/manifests/marin3r.clusterserviceversion.yaml
@@ -138,7 +138,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale-ops/marin3r
     support: Red Hat, Inc.
-  name: marin3r.v0.8.0-alpha.10
+  name: marin3r.v0.8.0-alpha.15
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -384,6 +384,9 @@ spec:
       - description: LastPublishedAt indicates the last time this config review transitioned to published
         displayName: Last Published At
         path: lastPublishedAt
+      - description: ProvidesVersions keeps track of the version that this revision publishes in the xDS server for each resource type
+        displayName: Provides Versions
+        path: providesVersions
       - description: Published signals if the EnvoyConfigRevision is the one currently published in the xds server cache
         displayName: Published
         path: published
@@ -502,6 +505,9 @@ spec:
       - description: Configures envoy's admin port. Defaults to 9901.
         displayName: Admin Port
         path: adminPort
+      - description: Affinity configuration for the envoy pods
+        displayName: Affinity
+        path: affinity
       - description: Defines the local service cluster name where Envoy is running. Defaults to the NodeID in the EnvoyConfig if unset
         displayName: Cluster ID
         path: clusterID
@@ -520,6 +526,12 @@ spec:
       - description: Image is the envoy image and tag to use
         displayName: Image
         path: image
+      - description: InitManager defines configuration for Envoy's init manager, which handles initialization for Envoy pods
+        displayName: Init Manager
+        path: initManager
+      - description: Image is the init manager image and tag to use
+        displayName: Image
+        path: initManager.image
       - description: Liveness probe for the envoy pods
         displayName: Liveness Probe
         path: livenessProbe
@@ -538,9 +550,6 @@ spec:
       - description: Number of seconds after which the probe times out
         displayName: Timeout Seconds
         path: livenessProbe.timeoutSeconds
-      - description: Affinity configuration for the envoy pods
-        displayName: Pod Affinity
-        path: podAffinity
       - description: Configures PodDisruptionBudget for the envoy Pods
         displayName: Pod Disruption Budget
         path: podDisruptionBudget
@@ -601,7 +610,7 @@ spec:
       - description: Resources holds the resource requirements to use for the Envoy Deployment. Defaults to no resource requests nor limits.
         displayName: Resources
         path: resources
-      - description: ShutdownManager defines configuration for Envoy's shutdown manager, which handles graceful termination of Envoy Pods
+      - description: ShutdownManager defines configuration for Envoy's shutdown manager, which handles graceful termination of Envoy pods
         displayName: Shutdown Manager
         path: shutdownManager
       - description: Image is the shutdown manager image and tag to use
@@ -696,7 +705,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/marin3r:v0.8.0-alpha.10
+                image: quay.io/3scale/marin3r:v0.8.0-alpha.15
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -741,7 +750,12 @@ spec:
                 - --tls-key-name=apiserver.key
                 command:
                 - /manager
-                image: quay.io/3scale/marin3r:v0.8.0-alpha.10
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                image: quay.io/3scale/marin3r:v0.8.0-alpha.15
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -768,6 +782,7 @@ spec:
                     memory: 30Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+              serviceAccountName: marin3r-controller-manager
       permissions:
       - rules:
         - apiGroups:
@@ -1057,7 +1072,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 0.8.0-alpha.10
+  version: 0.8.0-alpha.15
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/operator.marin3r.3scale.net_envoydeployments.yaml
+++ b/bundle/manifests/operator.marin3r.3scale.net_envoydeployments.yaml
@@ -37,57 +37,7 @@ spec:
                 description: Configures envoy's admin port. Defaults to 9901.
                 format: int32
                 type: integer
-              clusterID:
-                description: Defines the local service cluster name where Envoy is running. Defaults to the NodeID in the EnvoyConfig if unset
-                type: string
-              discoveryServiceRef:
-                description: DiscoveryServiceRef points to a DiscoveryService in the same namespace
-                type: string
-              duration:
-                description: Defines the duration of the client certificate that is used to authenticate with the DiscoveryService
-                type: string
-              envoyConfigRef:
-                description: EnvoyConfigRef points to an EnvoyConfig in the same namespace that holds the envoy resources for this Deployment
-                type: string
-              extraArgs:
-                description: Allows the user to define extra command line arguments for the Envoy process
-                items:
-                  type: string
-                type: array
-              image:
-                description: Image is the envoy image and tag to use
-                type: string
-              livenessProbe:
-                description: Liveness probe for the envoy pods
-                properties:
-                  failureThreshold:
-                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded
-                    format: int32
-                    type: integer
-                  initialDelaySeconds:
-                    description: Number of seconds after the container has started before liveness probes are initiated
-                    format: int32
-                    type: integer
-                  periodSeconds:
-                    description: How often (in seconds) to perform the probe
-                    format: int32
-                    type: integer
-                  successThreshold:
-                    description: Minimum consecutive successes for the probe to be considered successful after having failed
-                    format: int32
-                    type: integer
-                  timeoutSeconds:
-                    description: Number of seconds after which the probe times out
-                    format: int32
-                    type: integer
-                required:
-                - failureThreshold
-                - initialDelaySeconds
-                - periodSeconds
-                - successThreshold
-                - timeoutSeconds
-                type: object
-              podAffinity:
+              affinity:
                 description: Affinity configuration for the envoy pods
                 properties:
                   nodeAffinity:
@@ -427,6 +377,63 @@ spec:
                           type: object
                         type: array
                     type: object
+                type: object
+              clusterID:
+                description: Defines the local service cluster name where Envoy is running. Defaults to the NodeID in the EnvoyConfig if unset
+                type: string
+              discoveryServiceRef:
+                description: DiscoveryServiceRef points to a DiscoveryService in the same namespace
+                type: string
+              duration:
+                description: Defines the duration of the client certificate that is used to authenticate with the DiscoveryService
+                type: string
+              envoyConfigRef:
+                description: EnvoyConfigRef points to an EnvoyConfig in the same namespace that holds the envoy resources for this Deployment
+                type: string
+              extraArgs:
+                description: Allows the user to define extra command line arguments for the Envoy process
+                items:
+                  type: string
+                type: array
+              image:
+                description: Image is the envoy image and tag to use
+                type: string
+              initManager:
+                description: InitManager defines configuration for Envoy's init manager, which handles initialization for Envoy pods
+                properties:
+                  image:
+                    description: Image is the init manager image and tag to use
+                    type: string
+                type: object
+              livenessProbe:
+                description: Liveness probe for the envoy pods
+                properties:
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded
+                    format: int32
+                    type: integer
+                  initialDelaySeconds:
+                    description: Number of seconds after the container has started before liveness probes are initiated
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed
+                    format: int32
+                    type: integer
+                  timeoutSeconds:
+                    description: Number of seconds after which the probe times out
+                    format: int32
+                    type: integer
+                required:
+                - failureThreshold
+                - initialDelaySeconds
+                - periodSeconds
+                - successThreshold
+                - timeoutSeconds
                 type: object
               podDisruptionBudget:
                 description: Configures PodDisruptionBudget for the envoy Pods
@@ -936,7 +943,7 @@ spec:
                     type: object
                 type: object
               shutdownManager:
-                description: ShutdownManager defines configuration for Envoy's shutdown manager, which handles graceful termination of Envoy Pods
+                description: ShutdownManager defines configuration for Envoy's shutdown manager, which handles graceful termination of Envoy pods
                 properties:
                   image:
                     description: Image is the shutdown manager image and tag to use

--- a/config/crd/bases/operator.marin3r.3scale.net_envoydeployments.yaml
+++ b/config/crd/bases/operator.marin3r.3scale.net_envoydeployments.yaml
@@ -44,73 +44,7 @@ spec:
                 description: Configures envoy's admin port. Defaults to 9901.
                 format: int32
                 type: integer
-              clusterID:
-                description: Defines the local service cluster name where Envoy is
-                  running. Defaults to the NodeID in the EnvoyConfig if unset
-                type: string
-              discoveryServiceRef:
-                description: DiscoveryServiceRef points to a DiscoveryService in the
-                  same namespace
-                type: string
-              duration:
-                description: Defines the duration of the client certificate that is
-                  used to authenticate with the DiscoveryService
-                type: string
-              envoyConfigRef:
-                description: EnvoyConfigRef points to an EnvoyConfig in the same namespace
-                  that holds the envoy resources for this Deployment
-                type: string
-              extraArgs:
-                description: Allows the user to define extra command line arguments
-                  for the Envoy process
-                items:
-                  type: string
-                type: array
-              image:
-                description: Image is the envoy image and tag to use
-                type: string
-              initManager:
-                description: InitManager defines configuration for Envoy's init manager,
-                  which handles initialization for Envoy pods
-                properties:
-                  image:
-                    description: Image is the init manager image and tag to use
-                    type: string
-                type: object
-              livenessProbe:
-                description: Liveness probe for the envoy pods
-                properties:
-                  failureThreshold:
-                    description: Minimum consecutive failures for the probe to be
-                      considered failed after having succeeded
-                    format: int32
-                    type: integer
-                  initialDelaySeconds:
-                    description: Number of seconds after the container has started
-                      before liveness probes are initiated
-                    format: int32
-                    type: integer
-                  periodSeconds:
-                    description: How often (in seconds) to perform the probe
-                    format: int32
-                    type: integer
-                  successThreshold:
-                    description: Minimum consecutive successes for the probe to be
-                      considered successful after having failed
-                    format: int32
-                    type: integer
-                  timeoutSeconds:
-                    description: Number of seconds after which the probe times out
-                    format: int32
-                    type: integer
-                required:
-                - failureThreshold
-                - initialDelaySeconds
-                - periodSeconds
-                - successThreshold
-                - timeoutSeconds
-                type: object
-              podAffinity:
+              affinity:
                 description: Affinity configuration for the envoy pods
                 properties:
                   nodeAffinity:
@@ -700,6 +634,72 @@ spec:
                           type: object
                         type: array
                     type: object
+                type: object
+              clusterID:
+                description: Defines the local service cluster name where Envoy is
+                  running. Defaults to the NodeID in the EnvoyConfig if unset
+                type: string
+              discoveryServiceRef:
+                description: DiscoveryServiceRef points to a DiscoveryService in the
+                  same namespace
+                type: string
+              duration:
+                description: Defines the duration of the client certificate that is
+                  used to authenticate with the DiscoveryService
+                type: string
+              envoyConfigRef:
+                description: EnvoyConfigRef points to an EnvoyConfig in the same namespace
+                  that holds the envoy resources for this Deployment
+                type: string
+              extraArgs:
+                description: Allows the user to define extra command line arguments
+                  for the Envoy process
+                items:
+                  type: string
+                type: array
+              image:
+                description: Image is the envoy image and tag to use
+                type: string
+              initManager:
+                description: InitManager defines configuration for Envoy's init manager,
+                  which handles initialization for Envoy pods
+                properties:
+                  image:
+                    description: Image is the init manager image and tag to use
+                    type: string
+                type: object
+              livenessProbe:
+                description: Liveness probe for the envoy pods
+                properties:
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded
+                    format: int32
+                    type: integer
+                  initialDelaySeconds:
+                    description: Number of seconds after the container has started
+                      before liveness probes are initiated
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed
+                    format: int32
+                    type: integer
+                  timeoutSeconds:
+                    description: Number of seconds after which the probe times out
+                    format: int32
+                    type: integer
+                required:
+                - failureThreshold
+                - initialDelaySeconds
+                - periodSeconds
+                - successThreshold
+                - timeoutSeconds
                 type: object
               podDisruptionBudget:
                 description: Configures PodDisruptionBudget for the envoy Pods

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/marin3r
-  newTag: v0.8.0-alpha.10
+  newTag: v0.8.0-alpha.15

--- a/config/manifests/bases/marin3r.clusterserviceversion.yaml
+++ b/config/manifests/bases/marin3r.clusterserviceversion.yaml
@@ -257,6 +257,9 @@ spec:
       - description: LastPublishedAt indicates the last time this config review transitioned to published
         displayName: Last Published At
         path: lastPublishedAt
+      - description: ProvidesVersions keeps track of the version that this revision publishes in the xDS server for each resource type
+        displayName: Provides Versions
+        path: providesVersions
       - description: Published signals if the EnvoyConfigRevision is the one currently published in the xds server cache
         displayName: Published
         path: published
@@ -375,6 +378,9 @@ spec:
       - description: Configures envoy's admin port. Defaults to 9901.
         displayName: Admin Port
         path: adminPort
+      - description: Affinity configuration for the envoy pods
+        displayName: Affinity
+        path: affinity
       - description: Defines the local service cluster name where Envoy is running. Defaults to the NodeID in the EnvoyConfig if unset
         displayName: Cluster ID
         path: clusterID
@@ -393,6 +399,12 @@ spec:
       - description: Image is the envoy image and tag to use
         displayName: Image
         path: image
+      - description: InitManager defines configuration for Envoy's init manager, which handles initialization for Envoy pods
+        displayName: Init Manager
+        path: initManager
+      - description: Image is the init manager image and tag to use
+        displayName: Image
+        path: initManager.image
       - description: Liveness probe for the envoy pods
         displayName: Liveness Probe
         path: livenessProbe
@@ -411,9 +423,6 @@ spec:
       - description: Number of seconds after which the probe times out
         displayName: Timeout Seconds
         path: livenessProbe.timeoutSeconds
-      - description: Affinity configuration for the envoy pods
-        displayName: Pod Affinity
-        path: podAffinity
       - description: Configures PodDisruptionBudget for the envoy Pods
         displayName: Pod Disruption Budget
         path: podDisruptionBudget
@@ -474,7 +483,7 @@ spec:
       - description: Resources holds the resource requirements to use for the Envoy Deployment. Defaults to no resource requests nor limits.
         displayName: Resources
         path: resources
-      - description: ShutdownManager defines configuration for Envoy's shutdown manager, which handles graceful termination of Envoy Pods
+      - description: ShutdownManager defines configuration for Envoy's shutdown manager, which handles graceful termination of Envoy pods
         displayName: Shutdown Manager
         path: shutdownManager
       - description: Image is the shutdown manager image and tag to use

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -10,7 +10,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/marin3r
-  newTag: v0.8.0-alpha.10
+  newTag: v0.8.0-alpha.15
 
 patchesStrategicMerge:
 - |-

--- a/controllers/operator.marin3r/envoydeployment_controller.go
+++ b/controllers/operator.marin3r/envoydeployment_controller.go
@@ -143,7 +143,7 @@ func (r *EnvoyDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		Replicas:                  ed.Replicas(),
 		LivenessProbe:             ed.LivenessProbe(),
 		ReadinessProbe:            ed.ReadinessProbe(),
-		PodAffinity:               ed.PodAffinity(),
+		Affinity:                  ed.Affinity(),
 		PodDisruptionBudget:       ed.PodDisruptionBudget(),
 		ShutdownManager:           ed.Spec.ShutdownManager,
 		InitManager:               ed.Spec.InitManager,

--- a/pkg/reconcilers/operator/envoydeployment/generators/deployment.go
+++ b/pkg/reconcilers/operator/envoydeployment/generators/deployment.go
@@ -87,7 +87,7 @@ func (cfg *GeneratorOptions) Deployment(replicas *int32) lockedresources.Generat
 						Labels:            cfg.labels(),
 					},
 					Spec: corev1.PodSpec{
-						Affinity:                 cfg.PodAffinity,
+						Affinity:                 cfg.Affinity,
 						Volumes:                  cc.Volumes(),
 						InitContainers:           cc.InitContainers(),
 						Containers:               cc.Containers(),

--- a/pkg/reconcilers/operator/envoydeployment/generators/generator.go
+++ b/pkg/reconcilers/operator/envoydeployment/generators/generator.go
@@ -31,7 +31,7 @@ type GeneratorOptions struct {
 	Replicas                  operatorv1alpha1.ReplicasSpec
 	LivenessProbe             operatorv1alpha1.ProbeSpec
 	ReadinessProbe            operatorv1alpha1.ProbeSpec
-	PodAffinity               *corev1.Affinity
+	Affinity                  *corev1.Affinity
 	PodDisruptionBudget       operatorv1alpha1.PodDisruptionBudgetSpec
 	ShutdownManager           *operatorv1alpha1.ShutdownManager
 	InitManager               *operatorv1alpha1.InitManager

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.8.0-alpha.10"
+	version string = "v0.8.0-alpha.15"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
'podAffinity' was a poor choice for naming the field because it's basically the `affinity` field of a Pod spec. It's best if the naming is the same. This field has not make it yet to a stable release, so there is no problem in changing it.

/kind feature
/priority important-soon
/assign