### PR TITLE
Reduce the size of the docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,9 @@
 # Ignore build and test binaries.
 bin/
 testbin/
+# Ignore temporary stuff
+tmp/
+# Ignore docs - they're not needed in the images
+docs/
+# Ignore anything in the build dir
+build/*


### PR DESCRIPTION
We were sending a bunch of files to the Docker daemon that aren't
relevant to creating images. Adding a few exclusions cuts the build
context from ~320MB to ~6MB. This makes building a little more snappy
on slow machines.