### PR TITLE
Correctly sort ECRs when there are only two in the list

### DIFF
--- a/pkg/reconcilers/marin3r/envoyconfig/revisions/sort.go
+++ b/pkg/reconcilers/marin3r/envoyconfig/revisions/sort.go
@@ -8,18 +8,26 @@ import (
 )
 
 // SortByPublication sorts a list of EnvoyConfigRevisions using the following criteria
-// - if revision matches currentResourcesVersion, it always goes higher
+// - if revision matches desiredVersion, it always goes higher
 // - if publication date is defined, higher publication date goes higher
 // - if publication date is not defined, higher creation date goes higher
-func SortByPublication(currentResourcesVersion string, list *marin3rv1alpha1.EnvoyConfigRevisionList) *marin3rv1alpha1.EnvoyConfigRevisionList {
+func SortByPublication(desiredVersion string, list *marin3rv1alpha1.EnvoyConfigRevisionList) *marin3rv1alpha1.EnvoyConfigRevisionList {
 
 	ll := list.DeepCopy()
 
 	sort.SliceStable(ll.Items, func(i, j int) bool {
-		if ll.Items[j].Spec.Version == currentResourcesVersion {
+
+		// Override the chronological sort if either of the candidates is
+		// the desired one.
+		if ll.Items[j].Spec.Version == desiredVersion {
 			return true
 		}
+		if ll.Items[i].Spec.Version == desiredVersion {
+			return false
+		}
 
+		// Neither candidate is the desired one, so sort based on
+		// timestamps.
 		var iTime, jTime metav1.Time
 		if ll.Items[i].Status.LastPublishedAt.IsZero() {
 			iTime = ll.Items[i].GetCreationTimestamp()

--- a/pkg/reconcilers/marin3r/envoyconfig/revisions/sort_test.go
+++ b/pkg/reconcilers/marin3r/envoyconfig/revisions/sort_test.go
@@ -88,6 +88,48 @@ func TestSortByPublication(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Correctly sorts a list of only two items",
+			args: args{
+				currentResourcesVersion: "2",
+				list: &marin3rv1alpha1.EnvoyConfigRevisionList{
+					Items: []marin3rv1alpha1.EnvoyConfigRevision{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "ecr1", Namespace: "default"},
+							Spec:       marin3rv1alpha1.EnvoyConfigRevisionSpec{Version: "1"},
+							Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
+								LastPublishedAt: func(t metav1.Time) *metav1.Time { return &t }(metav1.NewTime(now.Add(-2 * time.Second))),
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "ecr2", Namespace: "default"},
+							Spec:       marin3rv1alpha1.EnvoyConfigRevisionSpec{Version: "2"},
+							Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
+								LastPublishedAt: func(t metav1.Time) *metav1.Time { return &t }(metav1.NewTime(now.Add(-4 * time.Second))),
+							},
+						},
+					},
+				},
+			},
+			want: &marin3rv1alpha1.EnvoyConfigRevisionList{
+				Items: []marin3rv1alpha1.EnvoyConfigRevision{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "ecr1", Namespace: "default"},
+						Spec:       marin3rv1alpha1.EnvoyConfigRevisionSpec{Version: "1"},
+						Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
+							LastPublishedAt: func(t metav1.Time) *metav1.Time { return &t }(metav1.NewTime(now.Add(-2 * time.Second))),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "ecr2", Namespace: "default"},
+						Spec:       marin3rv1alpha1.EnvoyConfigRevisionSpec{Version: "2"},
+						Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
+							LastPublishedAt: func(t metav1.Time) *metav1.Time { return &t }(metav1.NewTime(now.Add(-4 * time.Second))),
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
SortByPublication had a bug where it was checking only one of the
candidates' versions but not the other. If there are only two
candidates to be sorted then one's version wasn't being examined so
the sort ended up being based on publish date only, ignoring the
version.

Now we check both candidates' versions so version is always the
primary sort key, even when there are only two candidates.