### PR TITLE
feat/k8s-1.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,3 +407,6 @@ tmp: ## Create project tmp directory
 gen-pkg-image: export TARGET_PATH = $(PWD)/bin
 gen-pkg-image: ## builds the gen-pkg-image binary
 	 cd generators/pkg-image && go build -o $${TARGET_PATH}/gen-pkg-image main.go
+
+clean: ## Clean project directory
+	rm -rf tmp bin kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ catalog-push: ## Push a catalog image.
 
 kind-create: export KUBECONFIG = $(PWD)/kubeconfig
 kind-create: tmp docker-build kind ## Runs a k8s kind cluster with a local registry in "localhost:5000" and ports 1080 and 1443 exposed to the host
-	$(KIND) create cluster --wait 5m --config test/kind.yaml
+	$(KIND) create cluster --wait 5m --config test/kind.yaml --image kindest/node:v1.25.2
 	$(MAKE) deploy-cert-manager
 	$(KIND) load docker-image quay.io/3scale/marin3r:test --name kind
 
@@ -312,7 +312,7 @@ kind-delete: kind
 .PHONY: kind
 KIND = $(shell pwd)/bin/kind
 kind: ## Download kind locally if necessary
-	$(call go-get-tool,$(KIND),sigs.k8s.io/kind@v0.11.1)
+	$(call go-get-tool,$(KIND),sigs.k8s.io/kind@v0.16.0)
 
 ##@ Release
 

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ endif
 
 
 deploy-cert-manager: ## Deployes cert-manager in the K8s cluster specified in ~/.kube/config.
-	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
+	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.3/cert-manager.yaml
 	while [[ $$(kubectl -n cert-manager get deployment cert-manager-webhook -o 'jsonpath={.status.readyReplicas}') != "1" ]]; \
 		do echo "waiting for cert-manager webhook" && sleep 3; \
 	done

--- a/config/crd/bases/marin3r.3scale.net_envoyconfigrevisions.yaml
+++ b/config/crd/bases/marin3r.3scale.net_envoyconfigrevisions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: envoyconfigrevisions.marin3r.3scale.net
 spec:

--- a/config/crd/bases/marin3r.3scale.net_envoyconfigs.yaml
+++ b/config/crd/bases/marin3r.3scale.net_envoyconfigs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: envoyconfigs.marin3r.3scale.net
 spec:

--- a/config/crd/bases/operator.marin3r.3scale.net_discoveryservicecertificates.yaml
+++ b/config/crd/bases/operator.marin3r.3scale.net_discoveryservicecertificates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: discoveryservicecertificates.operator.marin3r.3scale.net
 spec:

--- a/config/crd/bases/operator.marin3r.3scale.net_discoveryservices.yaml
+++ b/config/crd/bases/operator.marin3r.3scale.net_discoveryservices.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: discoveryservices.operator.marin3r.3scale.net
 spec:

--- a/config/crd/bases/operator.marin3r.3scale.net_envoydeployments.yaml
+++ b/config/crd/bases/operator.marin3r.3scale.net_envoydeployments.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: envoydeployments.operator.marin3r.3scale.net
 spec:

--- a/controllers/operator.marin3r/envoydeployment_controller_suite_test.go
+++ b/controllers/operator.marin3r/envoydeployment_controller_suite_test.go
@@ -12,7 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -182,7 +182,7 @@ var _ = Describe("EnvoyDeployment controller", func() {
 
 			By("waiting for the envoy PDB to be created")
 			{
-				pdb := &policyv1beta1.PodDisruptionBudget{}
+				pdb := &policyv1.PodDisruptionBudget{}
 				key := types.NamespacedName{Name: "marin3r-envoydeployment-instance", Namespace: namespace}
 				Eventually(func() error {
 					return k8sClient.Get(context.Background(), key, pdb)

--- a/pkg/reconcilers/operator/envoydeployment/generators/pdb.go
+++ b/pkg/reconcilers/operator/envoydeployment/generators/pdb.go
@@ -2,7 +2,7 @@ package generators
 
 import (
 	"github.com/3scale-ops/marin3r/pkg/reconcilers/lockedresources"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -11,18 +11,18 @@ func (cfg *GeneratorOptions) PDB() lockedresources.GeneratorFunction {
 
 	return func() client.Object {
 
-		return &policyv1beta1.PodDisruptionBudget{
+		return &policyv1.PodDisruptionBudget{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "PodDisruptionBudget",
-				APIVersion: policyv1beta1.SchemeGroupVersion.String(),
+				APIVersion: policyv1.SchemeGroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      cfg.resourceName(),
 				Namespace: cfg.Namespace,
 				Labels:    cfg.labels(),
 			},
-			Spec: func() policyv1beta1.PodDisruptionBudgetSpec {
-				spec := policyv1beta1.PodDisruptionBudgetSpec{
+			Spec: func() policyv1.PodDisruptionBudgetSpec {
+				spec := policyv1.PodDisruptionBudgetSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: cfg.labels(),
 					},

--- a/pkg/reconcilers/operator/envoydeployment/generators/pdb_test.go
+++ b/pkg/reconcilers/operator/envoydeployment/generators/pdb_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -26,10 +26,10 @@ func TestGeneratorOptions_PDB(t *testing.T) {
 					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
 				},
 			},
-			want: &policyv1beta1.PodDisruptionBudget{
+			want: &policyv1.PodDisruptionBudget{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "PodDisruptionBudget",
-					APIVersion: policyv1beta1.SchemeGroupVersion.String(),
+					APIVersion: policyv1.SchemeGroupVersion.String(),
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "marin3r-envoydeployment-instance",
@@ -41,7 +41,7 @@ func TestGeneratorOptions_PDB(t *testing.T) {
 						"app.kubernetes.io/instance":   "instance",
 					},
 				},
-				Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{


### PR DESCRIPTION
PodDisruptionAPI v1beta1 is no longer available in k8s 1.25 so upgrade to v1. Also some minor tooling upgrades.

/kind feature
/priority important-soon
/assign

closes #141