### PR TITLE
Rework the SnapshotCache

### DIFF
--- a/controllers/marin3r/envoyconfigrevision_controller_test.go
+++ b/controllers/marin3r/envoyconfigrevision_controller_test.go
@@ -7,7 +7,6 @@ import (
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	xdss_v3 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v3"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
-	cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,7 +36,7 @@ func TestEnvoyConfigRevisionReconciler_taintSelf(t *testing.T) {
 		r := &EnvoyConfigRevisionReconciler{
 			Client:   fake.NewFakeClient(ecr),
 			Scheme:   scheme.Scheme,
-			XdsCache: xdss_v3.NewCache(cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)),
+			XdsCache: xdss_v3.NewCache(),
 			Log:      ctrl.Log.WithName("test"),
 		}
 		if err := r.taintSelf(context.TODO(), ecr, "test", "test", r.Log); err != nil {

--- a/controllers/marin3r/suite_test.go
+++ b/controllers/marin3r/suite_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	xdss_v3 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v3"
 	envoy "github.com/3scale-ops/marin3r/pkg/envoy"
-	cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/goombaio/namegenerator"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -113,7 +112,7 @@ var _ = BeforeSuite(func() {
 		Client:         mgr.GetClient(),
 		Log:            ctrl.Log.WithName("controllers").WithName("envoyconfigrevision_v3"),
 		Scheme:         mgr.GetScheme(),
-		XdsCache:       xdss_v3.NewCache(cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)),
+		XdsCache:       xdss_v3.NewCache(),
 		APIVersion:     envoy.APIv3,
 		DiscoveryStats: stats.New(),
 	}

--- a/pkg/discoveryservice/xds_server.go
+++ b/pkg/discoveryservice/xds_server.go
@@ -161,7 +161,7 @@ func (xdss *XdsServer) Start(stopCh <-chan struct{}) error {
 
 // GetCache returns the Cache
 func (xdss *XdsServer) GetCache(version envoy.APIVersion) xdss.Cache {
-	return xdss_v3.NewCache(xdss.snapshotCacheV3)
+	return xdss_v3.NewCacheFromSnapshotCache(xdss.snapshotCacheV3)
 }
 
 // GetCache returns the discovery stats

--- a/pkg/discoveryservice/xds_server_test.go
+++ b/pkg/discoveryservice/xds_server_test.go
@@ -116,7 +116,7 @@ func TestXdsServer_GetCache(t *testing.T) {
 				&xdss_v3.Callbacks{Logger: ctrl.Log},
 				stats.New(),
 			},
-			xdss_v3.NewCache(snapshotCacheV3),
+			xdss_v3.NewCache(),
 			envoy.APIv3,
 		},
 	}

--- a/pkg/discoveryservice/xdss/interface.go
+++ b/pkg/discoveryservice/xdss/interface.go
@@ -18,7 +18,7 @@ type Cache interface {
 	SetSnapshot(context.Context, string, Snapshot) error
 	GetSnapshot(string) (Snapshot, error)
 	ClearSnapshot(string)
-	NewSnapshot(string) Snapshot
+	NewSnapshot() Snapshot
 }
 
 // Snapshot is an internally consistent snapshot of xDS resources.
@@ -26,7 +26,7 @@ type Cache interface {
 // from the snapshot may be delivered to the proxy in arbitrary order.
 type Snapshot interface {
 	Consistent() error
-	SetResource(string, envoy.Resource)
+	SetResources(envoy.Type, []envoy.Resource) Snapshot
 	GetResources(envoy.Type) map[string]envoy.Resource
 	GetVersion(envoy.Type) string
 	SetVersion(envoy.Type, string)

--- a/pkg/discoveryservice/xdss/v3/cache.go
+++ b/pkg/discoveryservice/xdss/v3/cache.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	xdss "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss"
-	cache_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 )
+
+var _ xdss.Cache = Cache{}
 
 // Cache implements "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss".Cache for envoy API v3.
 type Cache struct {
@@ -15,7 +15,12 @@ type Cache struct {
 }
 
 // NewCache returns a Cache object.
-func NewCache(v3 cache_v3.SnapshotCache) Cache {
+func NewCache() Cache {
+	return Cache{v3: cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)}
+}
+
+// NewCache returns a Cache object.
+func NewCacheFromSnapshotCache(v3 cache_v3.SnapshotCache) Cache {
 	return Cache{v3: v3}
 }
 
@@ -41,22 +46,7 @@ func (c Cache) ClearSnapshot(nodeID string) {
 	c.v3.ClearSnapshot(nodeID)
 }
 
-// NewSnapshot returns a Snapshot object
-func (c Cache) NewSnapshot(resourcesVersion string) xdss.Snapshot {
+func (c Cache) NewSnapshot() xdss.Snapshot {
 
-	snap, _ := cache_v3.NewSnapshot(resourcesVersion,
-		map[resource_v3.Type][]cache_types.Resource{
-			resource_v3.EndpointType:        {},
-			resource_v3.ClusterType:         {},
-			resource_v3.RouteType:           {},
-			resource_v3.ScopedRouteType:     {},
-			resource_v3.VirtualHostType:     {},
-			resource_v3.ListenerType:        {},
-			resource_v3.SecretType:          {},
-			resource_v3.RuntimeType:         {},
-			resource_v3.ExtensionConfigType: {},
-		},
-	)
-
-	return Snapshot{v3: snap}
+	return NewSnapshot()
 }

--- a/pkg/discoveryservice/xdss/v3/cache_test.go
+++ b/pkg/discoveryservice/xdss/v3/cache_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	xdss "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss"
+	"github.com/3scale-ops/marin3r/pkg/envoy"
 	testutil "github.com/3scale-ops/marin3r/pkg/util/test"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	cache_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 )
 
@@ -24,38 +24,20 @@ func TestCache_SetSnapshot(t *testing.T) {
 		fields   fields
 		args     args
 		wantErr  bool
-		wantSnap Snapshot
+		wantSnap xdss.Snapshot
 	}{
 		{
 			name:   "Write the snapshot in the cache",
 			fields: fields{v3: cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)},
-			args: args{nodeID: "node", snap: Snapshot{v3: &cache_v3.Snapshot{
-				Resources: [9]cache_v3.Resources{
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{
-						"endpoint": {Resource: &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"}}}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-				}}}},
+			args: args{
+				nodeID: "node",
+				snap: NewSnapshot().SetResources(envoy.Endpoint, []envoy.Resource{
+					&envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"}}),
+			},
 			wantErr: false,
-			wantSnap: Snapshot{v3: &cache_v3.Snapshot{
-				Resources: [9]cache_v3.Resources{
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{
-						"endpoint": {Resource: &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"}}}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-				}}},
+			wantSnap: NewSnapshot().SetResources(envoy.Endpoint, []envoy.Resource{
+				&envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"},
+			}),
 		},
 	}
 	for _, tt := range tests {
@@ -75,77 +57,40 @@ func TestCache_SetSnapshot(t *testing.T) {
 }
 
 func TestCache_GetSnapshot(t *testing.T) {
-	type fields struct {
-		v3 cache_v3.SnapshotCache
-	}
 	type args struct {
 		nodeID string
 	}
 	tests := []struct {
 		name    string
-		fields  fields
+		cache   xdss.Cache
 		args    args
 		want    xdss.Snapshot
 		wantErr bool
 	}{
 		{
 			name: "Get the snapshot from the cache",
-			fields: fields{
-				v3: func() cache_v3.SnapshotCache {
-					c := cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)
-					c.SetSnapshot(context.TODO(), "node", &cache_v3.Snapshot{
-						Resources: [9]cache_v3.Resources{
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{
-								"endpoint": {Resource: &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"}}}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-						}})
-					return c
-				}(),
-			},
+			cache: func() Cache {
+				c := NewCache()
+				c.SetSnapshot(context.TODO(), "node", NewSnapshot().SetResources(envoy.Endpoint, []envoy.Resource{
+					&envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"},
+				}))
+				return c
+			}(),
 			args: args{nodeID: "node"},
-			want: Snapshot{v3: &cache_v3.Snapshot{
-				Resources: [9]cache_v3.Resources{
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{
-						"endpoint": {Resource: &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"}}}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-				}}},
+			want: NewSnapshot().SetResources(envoy.Endpoint, []envoy.Resource{
+				&envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"},
+			}),
 			wantErr: false,
 		},
 		{
 			name: "Snapshot does not exist for given nodeID, error returned",
-			fields: fields{
-				v3: func() cache_v3.SnapshotCache {
-					c := cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)
-					c.SetSnapshot(context.TODO(), "node", &cache_v3.Snapshot{
-						Resources: [9]cache_v3.Resources{
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{
-								"endpoint": {Resource: &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"}}}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-						}})
-					return c
-				}(),
-			},
+			cache: func() Cache {
+				c := NewCache()
+				c.SetSnapshot(context.TODO(), "node", NewSnapshot().SetResources(envoy.Endpoint, []envoy.Resource{
+					&envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"},
+				}))
+				return c
+			}(),
 			args:    args{nodeID: "other-node"},
 			want:    Snapshot{v3: &cache_v3.Snapshot{}},
 			wantErr: true,
@@ -153,9 +98,7 @@ func TestCache_GetSnapshot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := Cache{
-				v3: tt.fields.v3,
-			}
+			c := tt.cache
 			got, err := c.GetSnapshot(tt.args.nodeID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Cache.GetSnapshot() error = %v, wantErr %v", err, tt.wantErr)
@@ -169,92 +112,32 @@ func TestCache_GetSnapshot(t *testing.T) {
 }
 
 func TestCache_ClearSnapshot(t *testing.T) {
-	type fields struct {
-		v3 cache_v3.SnapshotCache
-	}
 	type args struct {
 		nodeID string
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
+		name  string
+		cache xdss.Cache
+		args  args
 	}{
 		{
 			name: "Snapshot deleted for the given nodeID",
-			fields: fields{
-				v3: func() cache_v3.SnapshotCache {
-					c := cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)
-					c.SetSnapshot(context.TODO(), "node", &cache_v3.Snapshot{
-						Resources: [9]cache_v3.Resources{
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{
-								"endpoint": {Resource: &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"}}}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-							{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-						}})
-					return c
-				}(),
-			},
+			cache: func() Cache {
+				c := NewCache()
+				c.SetSnapshot(context.TODO(), "node", NewSnapshot().SetResources(envoy.Endpoint, []envoy.Resource{
+					&envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint"},
+				}))
+				return c
+			}(),
 			args: args{nodeID: "node"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := Cache{
-				v3: tt.fields.v3,
-			}
+			c := tt.cache
 			c.ClearSnapshot(tt.args.nodeID)
 			if _, err := c.GetSnapshot("node"); err == nil {
 				t.Errorf("Cache.ClearSnapshot() = not found error expected")
-			}
-		})
-	}
-}
-
-func TestCache_NewSnapshot(t *testing.T) {
-	type fields struct {
-		v3 cache_v3.SnapshotCache
-	}
-	type args struct {
-		resourcesVersion string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   xdss.Snapshot
-	}{
-		{
-			name:   "Returns a new Snapshot object",
-			fields: fields{v3: cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)},
-			args:   args{resourcesVersion: "xxxx"},
-			want: Snapshot{v3: &cache_v3.Snapshot{
-				Resources: [9]cache_v3.Resources{
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-					{Version: "xxxx", Items: map[string]cache_types.ResourceWithTTL{}},
-				}}},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := Cache{
-				v3: tt.fields.v3,
-			}
-			if got := c.NewSnapshot(tt.args.resourcesVersion); !testutil.SnapshotsAreEqual(got, tt.want) {
-				t.Errorf("Cache.NewSnapshot() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/discoveryservice/xdss/v3/callbacks_test.go
+++ b/pkg/discoveryservice/xdss/v3/callbacks_test.go
@@ -19,40 +19,12 @@ import (
 	"testing"
 
 	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
-	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	cache_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
-
-func fakeTestCache() *cache_v3.SnapshotCache {
-
-	snapshotCache := cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil)
-
-	snapshotCache.SetSnapshot(context.TODO(), "node1", &cache_v3.Snapshot{
-		Resources: [9]cache_v3.Resources{
-			{Version: "1", Items: map[string]cache_types.ResourceWithTTL{
-				"endpoint1": {Resource: &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "endpoint1"}},
-			}},
-			{Version: "1", Items: map[string]cache_types.ResourceWithTTL{
-				"cluster1": {Resource: &envoy_config_cluster_v3.Cluster{Name: "cluster1"}},
-			}},
-			{Version: "1", Items: map[string]cache_types.ResourceWithTTL{}},
-			{Version: "1", Items: map[string]cache_types.ResourceWithTTL{}},
-			{Version: "1", Items: map[string]cache_types.ResourceWithTTL{}},
-			{Version: "1", Items: map[string]cache_types.ResourceWithTTL{}},
-			{Version: "1", Items: map[string]cache_types.ResourceWithTTL{}},
-			{Version: "1", Items: map[string]cache_types.ResourceWithTTL{}},
-		}},
-	)
-
-	return &snapshotCache
-}
 
 func TestCallbacks_OnStreamOpen(t *testing.T) {
 	type args struct {

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/cache.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/cache.go
@@ -69,20 +69,22 @@ func (r *CacheReconciler) Reconcile(ctx context.Context, req types.NamespacedNam
 }
 
 func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources *marin3rv1alpha1.EnvoyResources) (xdss.Snapshot, error) {
-	snap := r.xdsCache.NewSnapshot("")
+	snap := r.xdsCache.NewSnapshot()
 
+	endpoints := make([]envoy.Resource, 0, len(resources.Endpoints))
 	for idx, endpoint := range resources.Endpoints {
 		res := r.generator.New(envoy.Endpoint)
 		if err := r.decoder.Unmarshal(endpoint.Value, res); err != nil {
 			return nil,
 				resourceLoaderError(
-					req, endpoint.Value, field.NewPath("spec", "resources").Child("endpoint").Index(idx).Child("value"),
+					req, endpoint.Value, field.NewPath("spec", "resources").Child("endpoints").Index(idx).Child("value"),
 					fmt.Sprintf("Invalid envoy resource value: '%s'", err),
 				)
 		}
-		snap.SetResource(endpoint.Name, res)
+		endpoints = append(endpoints, res)
 	}
 
+	clusters := make([]envoy.Resource, 0, len(resources.Clusters))
 	for idx, cluster := range resources.Clusters {
 		res := r.generator.New(envoy.Cluster)
 		if err := r.decoder.Unmarshal(cluster.Value, res); err != nil {
@@ -92,9 +94,10 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources *
 					fmt.Sprintf("Invalid envoy resource value: '%s'", err),
 				)
 		}
-		snap.SetResource(cluster.Name, res)
+		clusters = append(clusters, res)
 	}
 
+	routes := make([]envoy.Resource, 0, len(resources.Routes))
 	for idx, route := range resources.Routes {
 		res := r.generator.New(envoy.Route)
 		if err := r.decoder.Unmarshal(route.Value, res); err != nil {
@@ -104,9 +107,10 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources *
 					fmt.Sprintf("Invalid envoy resource value: '%s'", err),
 				)
 		}
-		snap.SetResource(route.Name, res)
+		routes = append(routes, res)
 	}
 
+	scopedRoutes := make([]envoy.Resource, 0, len(resources.ScopedRoutes))
 	for idx, scopedRoute := range resources.ScopedRoutes {
 		res := r.generator.New(envoy.ScopedRoute)
 		if err := r.decoder.Unmarshal(scopedRoute.Value, res); err != nil {
@@ -116,33 +120,36 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources *
 					fmt.Sprintf("Invalid envoy resource value: '%s'", err),
 				)
 		}
-		snap.SetResource(scopedRoute.Name, res)
+		scopedRoutes = append(scopedRoutes, res)
 	}
 
+	listeners := make([]envoy.Resource, 0, len(resources.Listeners))
 	for idx, listener := range resources.Listeners {
 		res := r.generator.New(envoy.Listener)
 		if err := r.decoder.Unmarshal(listener.Value, res); err != nil {
 			return nil,
 				resourceLoaderError(
-					req, listener.Value, field.NewPath("spec", "resources").Child("listener").Index(idx).Child("value"),
+					req, listener.Value, field.NewPath("spec", "resources").Child("listeners").Index(idx).Child("value"),
 					fmt.Sprintf("Invalid envoy resource value: '%s'", err),
 				)
 		}
-		snap.SetResource(listener.Name, res)
+		listeners = append(listeners, res)
 	}
 
+	runtimes := make([]envoy.Resource, 0, len(resources.Runtimes))
 	for idx, runtime := range resources.Runtimes {
 		res := r.generator.New(envoy.Runtime)
 		if err := r.decoder.Unmarshal(runtime.Value, res); err != nil {
 			return nil,
 				resourceLoaderError(
-					req, runtime.Value, field.NewPath("spec", "resources").Child("runtime").Index(idx).Child("value"),
+					req, runtime.Value, field.NewPath("spec", "resources").Child("runtimes").Index(idx).Child("value"),
 					fmt.Sprintf("Invalid envoy resource value: '%s'", err),
 				)
 		}
-		snap.SetResource(runtime.Name, res)
+		runtimes = append(runtimes, res)
 	}
 
+	secrets := make([]envoy.Resource, 0, len(resources.Secrets))
 	for idx, secret := range resources.Secrets {
 		s := &corev1.Secret{}
 		key := secret.GetSecretKey(req.Namespace)
@@ -153,7 +160,7 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources *
 		// Validate secret holds a certificate
 		if s.Type == "kubernetes.io/tls" {
 			res := r.generator.NewSecret(secret.Name, string(s.Data[secretPrivateKey]), string(s.Data[secretCertificate]))
-			snap.SetResource(secret.Name, res)
+			secrets = append(secrets, res)
 		} else {
 			err := resourceLoaderError(
 				req, secret.Ref, field.NewPath("spec", "resources").Child("secrets").Index(idx).Child("ref"),
@@ -163,6 +170,14 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources *
 
 		}
 	}
+
+	snap.SetResources(envoy.Endpoint, endpoints)
+	snap.SetResources(envoy.Cluster, clusters)
+	snap.SetResources(envoy.Route, routes)
+	snap.SetResources(envoy.ScopedRoute, scopedRoutes)
+	snap.SetResources(envoy.Listener, listeners)
+	snap.SetResources(envoy.Secret, secrets)
+	snap.SetResources(envoy.Runtime, runtimes)
 
 	return snap, nil
 }

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/status_test.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/status_test.go
@@ -9,10 +9,7 @@ import (
 	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	xdss_v3 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v3"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
-	envoy_resources_v3 "github.com/3scale-ops/marin3r/pkg/envoy/resources/v3"
 	"github.com/davecgh/go-spew/spew"
-	cache_types "github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	cache_v3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/operator-framework/operator-lib/status"
 	"github.com/patrickmn/go-cache"
@@ -23,19 +20,8 @@ import (
 
 func testCacheGenerator(nodeID, version string) func() xdss.Cache {
 	return func() xdss.Cache {
-		cache := xdss_v3.NewCache(cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil))
-		snap, _ := cache_v3.NewSnapshot(version, map[string][]cache_types.Resource{
-			envoy_resources_v3.Mappings()[envoy.Endpoint]:        {},
-			envoy_resources_v3.Mappings()[envoy.Cluster]:         {},
-			envoy_resources_v3.Mappings()[envoy.Route]:           {},
-			envoy_resources_v3.Mappings()[envoy.ScopedRoute]:     {},
-			envoy_resources_v3.Mappings()[envoy.VirtualHost]:     {},
-			envoy_resources_v3.Mappings()[envoy.Listener]:        {},
-			envoy_resources_v3.Mappings()[envoy.Secret]:          {},
-			envoy_resources_v3.Mappings()[envoy.Runtime]:         {},
-			envoy_resources_v3.Mappings()[envoy.ExtensionConfig]: {},
-		})
-		cache.SetSnapshot(context.TODO(), nodeID, xdss_v3.NewSnapshot(snap))
+		cache := xdss_v3.NewCache()
+		cache.NewSnapshot()
 		return cache
 	}
 }
@@ -78,8 +64,12 @@ func TestIsStatusReconciled(t *testing.T) {
 						Runtimes:  "f",
 					}
 				},
-				xdssCacheFactory: testCacheGenerator("test", "xxxx"),
-				dStats:           stats.New,
+				xdssCacheFactory: func() xdss.Cache {
+					cache := xdss_v3.NewCache()
+					cache.SetSnapshot(context.TODO(), "test", cache.NewSnapshot())
+					return cache
+				},
+				dStats: stats.New,
 			},
 			want: false,
 		},
@@ -128,8 +118,12 @@ func TestIsStatusReconciled(t *testing.T) {
 						Runtimes:  "f",
 					}
 				},
-				xdssCacheFactory: testCacheGenerator("test", "xxxx"),
-				dStats:           stats.New,
+				xdssCacheFactory: func() xdss.Cache {
+					cache := xdss_v3.NewCache()
+					cache.SetSnapshot(context.TODO(), "test", cache.NewSnapshot())
+					return cache
+				},
+				dStats: stats.New,
 			},
 			want: true,
 		},
@@ -153,8 +147,12 @@ func TestIsStatusReconciled(t *testing.T) {
 					}
 				},
 				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return nil },
-				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
-				dStats:                stats.New,
+				xdssCacheFactory: func() xdss.Cache {
+					cache := xdss_v3.NewCache()
+					cache.SetSnapshot(context.TODO(), "test", cache.NewSnapshot())
+					return cache
+				},
+				dStats: stats.New,
 			},
 			want: false,
 		},
@@ -177,8 +175,12 @@ func TestIsStatusReconciled(t *testing.T) {
 					}
 				},
 				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return nil },
-				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
-				dStats:                stats.New,
+				xdssCacheFactory: func() xdss.Cache {
+					cache := xdss_v3.NewCache()
+					cache.SetSnapshot(context.TODO(), "test", cache.NewSnapshot())
+					return cache
+				},
+				dStats: stats.New,
 			},
 			want: true,
 		},
@@ -197,7 +199,11 @@ func TestIsStatusReconciled(t *testing.T) {
 						},
 					}
 				},
-				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
+				xdssCacheFactory: func() xdss.Cache {
+					cache := xdss_v3.NewCache()
+					cache.SetSnapshot(context.TODO(), "test", cache.NewSnapshot())
+					return cache
+				},
 				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return &marin3rv1alpha1.VersionTracker{Endpoints: "aaaa"} },
 				dStats: func() *stats.Stats {
 					return stats.NewWithItems(map[string]cache.Item{
@@ -232,7 +238,11 @@ func TestIsStatusReconciled(t *testing.T) {
 						},
 					}
 				},
-				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
+				xdssCacheFactory: func() xdss.Cache {
+					cache := xdss_v3.NewCache()
+					cache.SetSnapshot(context.TODO(), "test", cache.NewSnapshot())
+					return cache
+				},
 				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return &marin3rv1alpha1.VersionTracker{Endpoints: "aaaa"} },
 				dStats: func() *stats.Stats {
 					return stats.NewWithItems(map[string]cache.Item{
@@ -260,8 +270,12 @@ func TestIsStatusReconciled(t *testing.T) {
 					}
 				},
 				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return nil },
-				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
-				dStats:                stats.New,
+				xdssCacheFactory: func() xdss.Cache {
+					cache := xdss_v3.NewCache()
+					cache.SetSnapshot(context.TODO(), "test", cache.NewSnapshot())
+					return cache
+				},
+				dStats: stats.New,
 			},
 			want: false,
 		},
@@ -283,8 +297,12 @@ func TestIsStatusReconciled(t *testing.T) {
 					}
 				},
 				versionTrackerFactory: func() *marin3rv1alpha1.VersionTracker { return nil },
-				xdssCacheFactory:      testCacheGenerator("test", "xxxx"),
-				dStats:                stats.New,
+				xdssCacheFactory: func() xdss.Cache {
+					cache := xdss_v3.NewCache()
+					cache.SetSnapshot(context.TODO(), "test", cache.NewSnapshot())
+					return cache
+				},
+				dStats: stats.New,
 			},
 			want: true,
 		},
@@ -326,7 +344,11 @@ func Test_calculateResourcesInSyncCondition(t *testing.T) {
 						},
 					}
 				},
-				xdssCacheFactory: testCacheGenerator("test", "xxxx"),
+				xdssCacheFactory: func() xdss.Cache {
+					cache := xdss_v3.NewCache()
+					cache.SetSnapshot(context.TODO(), "test", cache.NewSnapshot())
+					return cache
+				},
 			},
 			want: corev1.ConditionTrue,
 		},
@@ -347,7 +369,7 @@ func Test_calculateResourcesInSyncCondition(t *testing.T) {
 					}
 				},
 				xdssCacheFactory: func() xdss.Cache {
-					cache := xdss_v3.NewCache(cache_v3.NewSnapshotCache(true, cache_v3.IDHash{}, nil))
+					cache := xdss_v3.NewCache()
 					return cache
 				},
 			},


### PR DESCRIPTION
The tests of different packages access the internal structure of the snapshot cache to validate correct behaviour. This causes a lot of work each time the internal structure of the snapshot cache changes in upstream go-control-plane repo. This PR reworks the cache to make use of new funcions in go-control-plane that make it easier to write/read to/from the cache and confines any access to the internal structure to just the pkg/discoveryservice/xdss/v3 package.

/kind feature
/priority important-longterm
/assign