### PR TITLE
Auto renew ca certificate

### DIFF
--- a/controllers/operator.marin3r/discoveryservice_controller.go
+++ b/controllers/operator.marin3r/discoveryservice_controller.go
@@ -34,19 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const (
-	// as there is currently no renewal mechanism for the CA
-	// set a validity sufficiently high. This might be configurable
-	// in the future when renewal is managed by the operator
-	caCertValidFor             int64  = 3600 * 24 * 365 * 3 // 3 years
-	serverCertValidFor         int64  = 3600 * 24 * 90      // 90 days
-	clientCertValidFor         int64  = 3600 * 48           // 48 hours
-	caCommonName               string = "marin3r-ca"
-	caCertSecretNamePrefix     string = "marin3r-ca-cert"
-	serverCommonName           string = "marin3r-server"
-	serverCertSecretNamePrefix string = "marin3r-server-cert"
-)
-
 var defaultExcludedPaths = []string{".metadata", ".status"}
 
 // DiscoveryServiceReconciler reconciles a DiscoveryService object

--- a/controllers/operator.marin3r/discoveryservice_controller_suite_test.go
+++ b/controllers/operator.marin3r/discoveryservice_controller_suite_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +27,7 @@ var _ = Describe("DiscoveryService controller", func() {
 		namespace = "test-ns-" + nameGenerator.Generate()
 
 		// Add any setup steps that needs to be executed before each test
-		testNamespace := &v1.Namespace{
+		testNamespace := &corev1.Namespace{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
 			ObjectMeta: metav1.ObjectMeta{Name: namespace},
 		}
@@ -36,7 +35,7 @@ var _ = Describe("DiscoveryService controller", func() {
 		err := k8sClient.Create(context.Background(), testNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		n := &v1.Namespace{}
+		n := &corev1.Namespace{}
 		Eventually(func() error {
 			return k8sClient.Get(context.Background(), types.NamespacedName{Name: namespace}, n)
 		}, 60*time.Second, 5*time.Second).ShouldNot(HaveOccurred())
@@ -86,10 +85,7 @@ var _ = Describe("DiscoveryService controller", func() {
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "instance", Namespace: namespace}, ds)
 				Expect(err).ToNot(HaveOccurred())
-				if len(ds.GetFinalizers()) > 0 {
-					return true
-				}
-				return false
+				return len(ds.GetFinalizers()) > 0
 			}, 60*time.Second, 5*time.Second).Should(BeTrue())
 		})
 

--- a/controllers/operator.marin3r/discoveryservicecertificate_controller.go
+++ b/controllers/operator.marin3r/discoveryservicecertificate_controller.go
@@ -105,7 +105,7 @@ func (r *DiscoveryServiceCertificateReconciler) IssuerChangedHandler() handler.E
 			issuer := o.(*operatorv1alpha1.DiscoveryServiceCertificate)
 			// Only interested in changes to CA certificates. A change in the CA
 			// means that the child certificates need to be re-issued
-			if !issuer.IsCA() || !issuer.GetCertificateRenewalConfig().Enabled {
+			if !issuer.IsCA() {
 				return []reconcile.Request{}
 			}
 

--- a/controllers/operator.marin3r/discoveryservicecertificate_controller_suite_test.go
+++ b/controllers/operator.marin3r/discoveryservicecertificate_controller_suite_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,7 +25,7 @@ var _ = Describe("DiscoveryServiceCertificate controller", func() {
 		namespace = "test-ns-" + nameGenerator.Generate()
 
 		// Add any setup steps that needs to be executed before each test
-		testNamespace := &v1.Namespace{
+		testNamespace := &corev1.Namespace{
 			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
 			ObjectMeta: metav1.ObjectMeta{Name: namespace},
 		}
@@ -34,13 +33,10 @@ var _ = Describe("DiscoveryServiceCertificate controller", func() {
 		err := k8sClient.Create(context.Background(), testNamespace)
 		Expect(err).ToNot(HaveOccurred())
 
-		n := &v1.Namespace{}
+		n := &corev1.Namespace{}
 		Eventually(func() bool {
 			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: namespace}, n)
-			if err != nil {
-				return false
-			}
-			return true
+			return err == nil
 		}, 60*time.Second, 5*time.Second).Should(BeTrue())
 
 	})

--- a/pkg/reconcilers/operator/discoveryservice/generators/certificate_root.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/certificate_root.go
@@ -37,7 +37,7 @@ func (cfg *GeneratorOptions) RootCertificationAuthority() lockedresources.Genera
 					Namespace: cfg.Namespace,
 				},
 				CertificateRenewalConfig: &operatorv1alpha1.CertificateRenewalConfig{
-					Enabled: false,
+					Enabled: true,
 				},
 			},
 		}

--- a/pkg/reconcilers/operator/discoveryservice/generators/certificate_root_test.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/certificate_root_test.go
@@ -68,7 +68,7 @@ func TestGeneratorOptions_RootCertificationAuthority(t *testing.T) {
 						Namespace: "default",
 					},
 					CertificateRenewalConfig: &operatorv1alpha1.CertificateRenewalConfig{
-						Enabled: false,
+						Enabled: true,
 					},
 				},
 			},


### PR DESCRIPTION
Adds a new event handler in the DiscoveryServiceCertificate controller to trigger a reconcile of any certificate that has its issuer certificate modified. After this, it is safe to enable auto-renewal of the discovery service CA certificate.

/kind feature
/assign
/priority important-longterm

Note for reviewers: https://github.com/3scale-ops/marin3r/pull/149 needs to be merged first and then I will rebase.