### PR TITLE
Don't restrict the types that can be unmarshalled

### DIFF
--- a/pkg/envoy/serializer/v3/serializer.go
+++ b/pkg/envoy/serializer/v3/serializer.go
@@ -7,13 +7,6 @@ import (
 
 	envoy "github.com/3scale-ops/marin3r/pkg/envoy"
 	_ "github.com/3scale-ops/marin3r/pkg/envoy/protos/v3"
-	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	envoy_service_runtime_v3 "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3"
 	"github.com/ghodss/yaml"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -40,38 +33,11 @@ func (s JSON) Marshal(res envoy.Resource) (string, error) {
 }
 
 func (s JSON) Unmarshal(str string, res envoy.Resource) error {
-
-	var err error
-	switch o := res.(type) {
-
-	case *envoy_config_endpoint_v3.ClusterLoadAssignment:
-		err = protojson.Unmarshal([]byte(str), o)
-
-	case *envoy_config_cluster_v3.Cluster:
-		err = protojson.Unmarshal([]byte(str), o)
-
-	case *envoy_config_route_v3.RouteConfiguration:
-		err = protojson.Unmarshal([]byte(str), o)
-
-	case *envoy_config_route_v3.ScopedRouteConfiguration:
-		err = protojson.Unmarshal([]byte(str), o)
-
-	case *envoy_config_listener_v3.Listener:
-		err = protojson.Unmarshal([]byte(str), o)
-
-	case *envoy_service_runtime_v3.Runtime:
-		err = protojson.Unmarshal([]byte(str), o)
-
-	case *envoy_extensions_transport_sockets_tls_v3.Secret:
-		err = protojson.Unmarshal([]byte(str), o)
-
-	case *envoy_config_core_v3.TypedExtensionConfig:
-		err = protojson.Unmarshal([]byte(str), o)
-
-	default:
-		err = fmt.Errorf("unknown resource type")
+	if res == nil {
+		return fmt.Errorf("resource cannot be nil")
 	}
 
+	err := protojson.Unmarshal([]byte(str), res)
 	if err != nil {
 		return fmt.Errorf("error deserializing resource: '%s'", err)
 	}

--- a/pkg/envoy/serializer/v3/serializer_test.go
+++ b/pkg/envoy/serializer/v3/serializer_test.go
@@ -348,7 +348,7 @@ func TestJSON_Unmarshal(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "Error deserializing resource: unknown type",
+			name:    "Error deserializing resource: cannot be nil",
 			s:       JSON{},
 			args:    args{str: `{"this_is": "wrong"}`, res: nil},
 			want:    nil,


### PR DESCRIPTION
Make the unmarshal possible for any proto message, not just the top level ones. This is useful for when the serializer package is used form other project.

/kind feature
/priority important-longterm
/assign