### PR TITLE
feat/endpoint-discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,9 +302,7 @@ endif
 
 deploy-cert-manager: ## Deployes cert-manager in the K8s cluster specified in ~/.kube/config.
 	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.3/cert-manager.yaml
-	while [[ $$(kubectl -n cert-manager get deployment cert-manager-webhook -o 'jsonpath={.status.readyReplicas}') != "1" ]]; \
-		do echo "waiting for cert-manager webhook" && sleep 3; \
-	done
+	kubectl -n cert-manager wait --timeout=300s --for=condition=Available deployments --all
 
 # Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
 # This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -74,6 +74,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - marin3r.3scale.net
   resources:
   - '*'

--- a/controllers/marin3r/envoyconfigrevision_controller.go
+++ b/controllers/marin3r/envoyconfigrevision_controller.go
@@ -63,6 +63,7 @@ type EnvoyConfigRevisionReconciler struct {
 // +kubebuilder:rbac:groups=marin3r.3scale.net,namespace=placeholder,resources=envoyconfigrevisions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=marin3r.3scale.net,namespace=placeholder,resources=envoyconfigrevisions/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="core",namespace=placeholder,resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="discovery.k8s.io",namespace=placeholder,resources=endpointslices,verbs=get;list;watch
 func (r *EnvoyConfigRevisionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("name", req.Name, "namespace", req.Namespace)
 

--- a/controllers/operator.marin3r/discoveryservice_controller.go
+++ b/controllers/operator.marin3r/discoveryservice_controller.go
@@ -52,6 +52,7 @@ type DiscoveryServiceReconciler struct {
 // +kubebuilder:rbac:groups=operator.marin3r.3scale.net,namespace=placeholder,resources=discoveryservicecertificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="core",namespace=placeholder,resources=pods,verbs=list;watch;get
 // +kubebuilder:rbac:groups="core",namespace=placeholder,resources=secrets,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="discovery.k8s.io",namespace=placeholder,resources=endpointslices,verbs=get;list;watch
 
 func (r *DiscoveryServiceReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("name", request.Name, "namespace", request.Namespace)

--- a/examples/e2e/deployment/envoyconfig.yaml
+++ b/examples/e2e/deployment/envoyconfig.yaml
@@ -4,53 +4,16 @@ metadata:
   name: kuard
 spec:
   nodeID: kuard
-  serialization: yaml
-  envoyAPI: v3
-  envoyResources:
-    secrets:
-      - name: kuard.default.svc
-        ref:
-          name: kuard
-    clusters:
-      - value: |
-          name: kuard
-          connect_timeout: 0.010s
-          type: STRICT_DNS
-          dns_lookup_family: V4_ONLY
-          lb_policy: ROUND_ROBIN
-          load_assignment:
-            cluster_name: kuard
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: kuard
-                          port_value: 8080
-    routes:
-      - value: |
-          name: kuard
-          virtual_hosts:
-            - name: all
-              domains: ["*"]
-              routes:
-                - { match: {prefix: "/"}, route: { cluster: "kuard" }}
-    scopedRoutes:
-      - value: |
-          name: scoped_route_kuard
-          route_configuration_name: kuard
-          key:
-            fragments:
-              - string_key: kuard
-    listeners:
-      - value: |
-          name: https
-          address:
-            socket_address:
-              address: 0.0.0.0
-              port_value: 8443
-          filter_chains:
-            - filters:
+  resources:
+    - type: listener
+      value:
+        name: https
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 8443
+        filter_chains:
+          - filters:
               - name: envoy.filters.network.http_connection_manager
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
@@ -60,53 +23,52 @@ spec:
                         "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
                         path: /dev/stdout
                   stat_prefix: ingress_http
-                  rds: { route_config_name: "kuard", config_source: { ads: {}, resource_api_version: "V3" }}
+                  rds:
+                    route_config_name: "kuard"
+                    config_source:
+                      ads: {}
+                      resource_api_version: "V3"
                   http_filters:
                     - name: envoy.filters.http.router
-              transport_socket:
-                name: envoy.transport_sockets.tls
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-                  common_tls_context:
-                    tls_certificate_sds_secret_configs:
-                      - name: kuard.default.svc
-                        sds_config: { ads: {}, resource_api_version: "V3" }
-      - value: |
-          name: https-scoped
-          address:
-            socket_address:
-              address: 0.0.0.0
-              port_value: 8444
-          filter_chains:
-            - filters:
-                - name: envoy.filters.network.http_connection_manager
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                    access_log:
-                      - name: envoy.access_loggers.file
-                        typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                          path: /dev/stdout
-                    stat_prefix: ingress_http
-                    scoped_routes:
-                      name: scoped
-                      scope_key_builder:
-                        fragments:
-                          - header_value_extractor:
-                              name: X-Route-Selector
-                              element_separator: ","
-                              element:
-                                separator: "="
-                                key: route
-                      rds_config_source: { ads: {}, resource_api_version: "V3" }
-                      scoped_rds: { scoped_rds_config_source: { ads: {}, resource_api_version: "V3" }}
-                    http_filters:
-                      - name: envoy.filters.http.router
-              transport_socket:
-                name: envoy.transport_sockets.tls
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-                  common_tls_context:
-                    tls_certificate_sds_secret_configs:
-                      - name: kuard.default.svc
-                        sds_config: { ads: {}, resource_api_version: "V3" }
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            transport_socket:
+              name: envoy.transport_sockets.tls
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                common_tls_context:
+                  tls_certificate_sds_secret_configs:
+                    - name: kuard
+                      sds_config:
+                        ads: {}
+                        resource_api_version: "V3"
+    - type: secret
+      generateFromTlsSecret: kuard
+    - type: route
+      value:
+        name: kuard
+        virtual_hosts:
+          - name: all
+            domains: ["*"]
+            routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: "kuard"
+    - type: cluster
+      value:
+        name: kuard
+        connect_timeout: 0.010s
+        type: EDS
+        lb_policy: ROUND_ROBIN
+        eds_cluster_config:
+          eds_config:
+            ads: {}
+            resource_api_version: "V3"
+    - type: endpoint
+      generateFromEndpointSlices:
+        selector:
+          matchLabels:
+            kubernetes.io/service-name: kuard
+        clusterName: kuard
+        targetPort: http

--- a/examples/e2e/deployment/kuard.yaml
+++ b/examples/e2e/deployment/kuard.yaml
@@ -35,6 +35,7 @@ spec:
   selector:
     app: kuard
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 8080
       targetPort: http

--- a/examples/local/envoyconfig.yaml
+++ b/examples/local/envoyconfig.yaml
@@ -1,0 +1,74 @@
+apiVersion: marin3r.3scale.net/v1alpha1
+kind: EnvoyConfig
+metadata:
+  name: ec-v1alpha2
+  namespace: default
+spec:
+  nodeID: ec-v1alpha2
+  resources:
+    - type: cluster
+      value:
+        name: echo_api
+        connect_timeout: 1s
+        type: STRICT_DNS
+        dns_lookup_family: V4_ONLY
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: echo_api
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: echo-api.3scale.net
+                        port_value: 443
+        transport_socket:
+          name: envoy.transport_sockets.tls
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+            sni: echo-api.3scale.net
+
+    - type: route
+      value:
+        name: echo-api.3scale.net
+        virtual_hosts:
+          - name: ingress
+            domains: ["*"]
+            routes:
+              - match:
+                  prefix: "/"
+                route:
+                  auto_host_rewrite: true
+                  cluster: echo_api
+
+    - type: listener
+      value:
+        name: http
+        address: {socket_address: {address: 0.0.0.0, port_value: 8888}}
+        filter_chains:
+          - filters:
+              - name: envoy.filters.network.http_connection_manager
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                  access_log:
+                    - name: envoy.access_loggers.file
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                        path: /dev/stdout
+                  stat_prefix: ingress_http
+                  rds:
+                    route_config_name: "echo-api.3scale.net"
+                    config_source: {ads: {}, resource_api_version: V3}
+                  http_filters:
+                    - name: "http_router"
+                      config_discovery:
+                        config_source: {ads: {}, resource_api_version: V3}
+                        type_urls:
+                          - "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+
+    - type: extensionConfig
+      value:
+        name: http_router
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          dynamic_stats: false

--- a/pkg/envoy/resources/generator.go
+++ b/pkg/envoy/resources/generator.go
@@ -11,6 +11,7 @@ type Generator interface {
 	New(rType envoy.Type) envoy.Resource
 	NewSecret(string, string, string) envoy.Resource
 	NewSecretFromPath(string, string, string) envoy.Resource
+	NewClusterLoadAssignment(string, ...envoy.UpstreamHost) envoy.Resource
 }
 
 // NewGenerator returns a generator struct for the given API version

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -2,6 +2,7 @@ package envoy
 
 import (
 	"fmt"
+	"net"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -59,3 +60,31 @@ const (
 	// ExtensionConfig is an envoy extension config resource
 	ExtensionConfig Type = "extensionConfig"
 )
+
+type EndpointHealthStatus int32
+
+const (
+	// The health status is not known. This is interpreted by Envoy as ``HEALTHY``.
+	HealthStatus_UNKNOWN EndpointHealthStatus = 0
+	// Healthy.
+	HealthStatus_HEALTHY EndpointHealthStatus = 1
+	// Unhealthy.
+	HealthStatus_UNHEALTHY EndpointHealthStatus = 2
+	// Connection draining in progress. E.g.,
+	// `<https://aws.amazon.com/blogs/aws/elb-connection-draining-remove-instances-from-service-with-care/>`_
+	// or
+	// `<https://cloud.google.com/compute/docs/load-balancing/enabling-connection-draining>`_.
+	// This is interpreted by Envoy as ``UNHEALTHY``.
+	HealthStatus_DRAINING EndpointHealthStatus = 3
+	// Health check timed out. This is part of HDS and is interpreted by Envoy as
+	// ``UNHEALTHY``.
+	HealthStatus_TIMEOUT EndpointHealthStatus = 4
+	// Degraded.
+	HealthStatus_DEGRADED EndpointHealthStatus = 5
+)
+
+type UpstreamHost struct {
+	IP     net.IP
+	Port   uint32
+	Health EndpointHealthStatus
+}

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/discover/endpoints.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/discover/endpoints.go
@@ -1,0 +1,127 @@
+package discover
+
+import (
+	"fmt"
+	"net"
+
+	"context"
+
+	"github.com/3scale-ops/marin3r/pkg/envoy"
+	envoy_resources "github.com/3scale-ops/marin3r/pkg/envoy/resources"
+	"github.com/go-logr/logr"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Endpoints(ctx context.Context, cl client.Client, namespace string,
+	clusterName, portName string, labelSelector *metav1.LabelSelector,
+	generator envoy_resources.Generator, log logr.Logger) (envoy.Resource, error) {
+
+	esl := &discoveryv1.EndpointSliceList{}
+
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cl.List(ctx, esl, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		return nil, err
+	}
+
+	if len(esl.Items) == 0 {
+		return nil, fmt.Errorf("no endpoints returned for label selector '%s'", selector)
+	}
+
+	hosts, err := endpointSlices_to_UpstreamHosts(esl, portName, log)
+	if err != nil {
+		return nil, err
+	}
+	endpoints := generator.NewClusterLoadAssignment(clusterName, hosts...)
+
+	return endpoints, nil
+}
+
+func endpointSlices_to_UpstreamHosts(esl *discoveryv1.EndpointSliceList, portName string, log logr.Logger) ([]envoy.UpstreamHost, error) {
+	hosts := []envoy.UpstreamHost{}
+	var port *int32
+
+	if esl.Items[0].AddressType == discoveryv1.AddressTypeFQDN {
+		return nil, fmt.Errorf("unsupported address type FQDN")
+	}
+
+	// find the port
+	for _, p := range esl.Items[0].Ports {
+		if p.Name != nil && *p.Name == portName {
+			port = p.Port
+			break
+		}
+	}
+	if port == nil {
+		return nil, fmt.Errorf("no port by the name of '%s' found", portName)
+	}
+
+	// generate the list of hosts
+	for _, endpointSlice := range esl.Items {
+
+		for _, item := range endpointSlice.Endpoints {
+			// only using address in position zero, see https://github.com/kubernetes/kubernetes/issues/106267
+			if ip := net.ParseIP(item.Addresses[0]); ip == nil {
+				log.Error(fmt.Errorf("'%s' doesn't look like an IP address", item.Addresses[0]), "error parsing endpoint")
+				continue
+			} else {
+
+				hosts = append(hosts, envoy.UpstreamHost{
+					IP:     ip,
+					Port:   uint32(*port),
+					Health: health(item.Conditions),
+				})
+			}
+
+		}
+	}
+
+	return hosts, nil
+}
+
+func health(ec discoveryv1.EndpointConditions) envoy.EndpointHealthStatus {
+	var health envoy.EndpointHealthStatus = envoy.HealthStatus_UNKNOWN
+
+	// 1. determine if terminating
+	if ec.Terminating != nil && *ec.Terminating {
+		health = envoy.HealthStatus_DRAINING
+
+	} else {
+
+		// 2. Use 'serving' to determine health
+		if ec.Serving != nil {
+
+			if *ec.Serving {
+				health = envoy.HealthStatus_HEALTHY
+			} else {
+				health = envoy.HealthStatus_UNHEALTHY
+			}
+
+		} else {
+
+			// 3. fall back to 'ready' if 'serving' not set
+			if ec.Ready != nil {
+
+				if *ec.Ready {
+					health = envoy.HealthStatus_HEALTHY
+				} else {
+					health = envoy.HealthStatus_UNHEALTHY
+				}
+
+			} else {
+				// neither 'ready' nor 'serving' fields availabel, unable
+				// to determine health
+				health = envoy.HealthStatus_UNKNOWN
+			}
+
+		}
+
+	}
+
+	return health
+}

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/discover/endpoints_test.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/discover/endpoints_test.go
@@ -1,0 +1,439 @@
+package discover
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/3scale-ops/marin3r/pkg/envoy"
+	envoy_resources "github.com/3scale-ops/marin3r/pkg/envoy/resources"
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/go-logr/logr"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestEndpoints(t *testing.T) {
+	type args struct {
+		ctx           context.Context
+		cl            client.Client
+		namespace     string
+		clusterName   string
+		portName      string
+		labelSelector *metav1.LabelSelector
+		generator     envoy_resources.Generator
+		log           logr.Logger
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    envoy.Resource
+		wantErr bool
+	}{
+		{
+			name: "Produces a cluster load assignment (endpoint) envoy resource",
+			args: args{
+				ctx: context.TODO(),
+				cl: fake.NewClientBuilder().WithObjects(
+					&discoveryv1.EndpointSlice{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "ns",
+							Labels: map[string]string{
+								"key": "value",
+							},
+						},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses:  []string{"127.0.0.1"},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+							},
+							{
+								Addresses:  []string{"127.0.0.2"},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+							},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: pointer.String("port"), Port: pointer.Int32(1001)},
+						},
+					},
+				).Build(),
+				namespace:     "ns",
+				clusterName:   "cluster",
+				portName:      "port",
+				labelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"key": "value"}},
+				generator:     envoy_resources.NewGenerator(envoy.APIv3),
+				log:           ctrl.Log.WithName("test"),
+			},
+			want: &envoy_config_endpoint_v3.ClusterLoadAssignment{
+				ClusterName: "cluster",
+				Endpoints: []*envoy_config_endpoint_v3.LocalityLbEndpoints{
+					{
+						LbEndpoints: []*envoy_config_endpoint_v3.LbEndpoint{
+							{
+								HostIdentifier: &envoy_config_endpoint_v3.LbEndpoint_Endpoint{
+									Endpoint: &envoy_config_endpoint_v3.Endpoint{
+										Address: &envoy_config_core_v3.Address{
+											Address: &envoy_config_core_v3.Address_SocketAddress{
+												SocketAddress: &envoy_config_core_v3.SocketAddress{
+													Address: "127.0.0.1",
+													PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+														PortValue: 1001,
+													},
+												},
+											},
+										},
+									},
+								},
+								HealthStatus: envoy_config_core_v3.HealthStatus_HEALTHY,
+							},
+							{
+								HostIdentifier: &envoy_config_endpoint_v3.LbEndpoint_Endpoint{
+									Endpoint: &envoy_config_endpoint_v3.Endpoint{
+										Address: &envoy_config_core_v3.Address{
+											Address: &envoy_config_core_v3.Address_SocketAddress{
+												SocketAddress: &envoy_config_core_v3.SocketAddress{
+													Address: "127.0.0.2",
+													PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+														PortValue: 1001,
+													},
+												},
+											},
+										},
+									},
+								},
+								HealthStatus: envoy_config_core_v3.HealthStatus_HEALTHY,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error, no endpoints returned (port not matched)",
+			args: args{
+				ctx: context.TODO(),
+				cl: fake.NewClientBuilder().WithObjects(
+					&discoveryv1.EndpointSlice{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "ns",
+							Labels: map[string]string{
+								"key": "value",
+							},
+						},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses:  []string{"127.0.0.1"},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+							},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: pointer.String("port"), Port: pointer.Int32(1001)},
+						},
+					},
+				).Build(),
+				namespace:     "ns",
+				clusterName:   "cluster",
+				portName:      "non-existent-port",
+				labelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"key": "value"}},
+				generator:     envoy_resources.NewGenerator(envoy.APIv3),
+				log:           ctrl.Log.WithName("test"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Error, no endpoints returned for given label selector",
+			args: args{
+				ctx: context.TODO(),
+				cl: fake.NewClientBuilder().WithObjects(
+					&discoveryv1.EndpointSlice{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "ns",
+							Labels: map[string]string{
+								"key": "xxxx",
+							},
+						},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses:  []string{"127.0.0.1"},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+							},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: pointer.String("port"), Port: pointer.Int32(1001)},
+						},
+					},
+				).Build(),
+				namespace:     "ns",
+				clusterName:   "cluster",
+				portName:      "non-existent-port",
+				labelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"key": "value"}},
+				generator:     envoy_resources.NewGenerator(envoy.APIv3),
+				log:           ctrl.Log.WithName("test"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Endpoints(tt.args.ctx, tt.args.cl, tt.args.namespace, tt.args.clusterName, tt.args.portName, tt.args.labelSelector, tt.args.generator, tt.args.log)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Endpoints() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Endpoints() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_endpointSlices_to_UpstreamHosts(t *testing.T) {
+	type args struct {
+		esl      *discoveryv1.EndpointSliceList
+		portName string
+		log      logr.Logger
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []envoy.UpstreamHost
+		wantErr bool
+	}{
+		{
+			name: "Generated the list of upstream hosts",
+			args: args{
+				esl: &discoveryv1.EndpointSliceList{
+					Items: []discoveryv1.EndpointSlice{
+						{
+							AddressType: discoveryv1.AddressTypeIPv4,
+							Endpoints: []discoveryv1.Endpoint{
+								{
+									Addresses:  []string{"127.0.0.1"},
+									Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+								},
+								{
+									Addresses:  []string{"127.0.0.2"},
+									Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+								},
+							},
+							Ports: []discoveryv1.EndpointPort{
+								{Name: pointer.String("port1"), Port: pointer.Int32(1001)},
+								{Name: pointer.String("port2"), Port: pointer.Int32(1002)},
+							},
+						},
+						{
+							AddressType: discoveryv1.AddressTypeIPv4,
+							Endpoints: []discoveryv1.Endpoint{
+								{
+									Addresses:  []string{"127.0.0.3"},
+									Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+								},
+								{
+									Addresses:  []string{"127.0.0.4"},
+									Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(false)},
+								},
+							},
+							Ports: []discoveryv1.EndpointPort{
+								{Name: pointer.String("port1"), Port: pointer.Int32(1001)},
+								{Name: pointer.String("port2"), Port: pointer.Int32(1002)},
+							},
+						},
+					},
+				},
+				portName: "port1",
+				log:      ctrl.Log.WithName("test"),
+			},
+			want: []envoy.UpstreamHost{
+				{
+					IP:     net.ParseIP("127.0.0.1"),
+					Port:   1001,
+					Health: envoy.HealthStatus_HEALTHY,
+				},
+				{
+					IP:     net.ParseIP("127.0.0.2"),
+					Port:   1001,
+					Health: envoy.HealthStatus_HEALTHY,
+				},
+				{
+					IP:     net.ParseIP("127.0.0.3"),
+					Port:   1001,
+					Health: envoy.HealthStatus_HEALTHY,
+				},
+				{
+					IP:     net.ParseIP("127.0.0.4"),
+					Port:   1001,
+					Health: envoy.HealthStatus_UNHEALTHY,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error, unsupported address type",
+			args: args{
+				esl: &discoveryv1.EndpointSliceList{
+					Items: []discoveryv1.EndpointSlice{{AddressType: discoveryv1.AddressTypeFQDN}},
+				},
+				portName: "port1",
+				log:      ctrl.Log.WithName("test"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Error, port not found",
+			args: args{
+				esl: &discoveryv1.EndpointSliceList{
+					Items: []discoveryv1.EndpointSlice{{
+						Ports: []discoveryv1.EndpointPort{
+							{Name: pointer.String("port1"), Port: pointer.Int32(1001)},
+						}}},
+				},
+				portName: "other-port",
+				log:      ctrl.Log.WithName("test"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Continues on invalid IP address",
+			args: args{
+				esl: &discoveryv1.EndpointSliceList{
+					Items: []discoveryv1.EndpointSlice{{
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{
+								Addresses:  []string{"xxxx"},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+							},
+							{
+								Addresses:  []string{"127.0.0.2"},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+							},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: pointer.String("port1"), Port: pointer.Int32(1001)},
+						},
+					}},
+				},
+				portName: "port1",
+				log:      ctrl.Log.WithName("test"),
+			},
+			want: []envoy.UpstreamHost{{
+				IP:     net.ParseIP("127.0.0.2"),
+				Port:   1001,
+				Health: envoy.HealthStatus_HEALTHY,
+			}},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := endpointSlices_to_UpstreamHosts(tt.args.esl, tt.args.portName, tt.args.log)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("endpointSlices_to_UpstreamHosts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("endpointSlices_to_UpstreamHosts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_health(t *testing.T) {
+	type args struct {
+		ec discoveryv1.EndpointConditions
+	}
+	tests := []struct {
+		name string
+		args args
+		want envoy.EndpointHealthStatus
+	}{
+		{
+			name: "HEALTHY",
+			args: args{
+				ec: discoveryv1.EndpointConditions{
+					Ready:       pointer.Bool(true),
+					Serving:     pointer.Bool(true),
+					Terminating: pointer.Bool(false),
+				},
+			},
+			want: envoy.HealthStatus_HEALTHY,
+		},
+		{
+			name: "HEALTHY",
+			args: args{
+				ec: discoveryv1.EndpointConditions{
+					Ready:   pointer.Bool(true),
+					Serving: pointer.Bool(true),
+				},
+			},
+			want: envoy.HealthStatus_HEALTHY,
+		},
+		{
+			name: "HEALTHY",
+			args: args{
+				ec: discoveryv1.EndpointConditions{
+					Ready: pointer.Bool(true),
+				},
+			},
+			want: envoy.HealthStatus_HEALTHY,
+		},
+		{
+			name: "UNHEALTHY",
+			args: args{
+				ec: discoveryv1.EndpointConditions{
+					Ready: pointer.Bool(false),
+				},
+			},
+			want: envoy.HealthStatus_UNHEALTHY,
+		},
+		{
+			name: "UNHEALTHY",
+			args: args{
+				ec: discoveryv1.EndpointConditions{
+					Serving: pointer.Bool(false),
+				},
+			},
+			want: envoy.HealthStatus_UNHEALTHY,
+		},
+		{
+			name: "UNKNOWN",
+			args: args{
+				ec: discoveryv1.EndpointConditions{},
+			},
+			want: envoy.HealthStatus_UNKNOWN,
+		},
+		{
+			name: "DRAINING",
+			args: args{
+				ec: discoveryv1.EndpointConditions{
+					Terminating: pointer.Bool(true),
+				},
+			},
+			want: envoy.HealthStatus_DRAINING,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := health(tt.args.ec); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("health() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/reconcilers/operator/discoveryservice/generators/role.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/role.go
@@ -3,6 +3,7 @@ package generators
 import (
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -31,6 +32,11 @@ func (cfg *GeneratorOptions) Role() func() *rbacv1.Role {
 					APIGroups: []string{marin3rv1alpha1.GroupVersion.Group},
 					Resources: []string{rbacv1.ResourceAll},
 					Verbs:     []string{rbacv1.VerbAll},
+				},
+				{
+					APIGroups: []string{discoveryv1.SchemeGroupVersion.Group},
+					Resources: []string{"endpointslices"},
+					Verbs:     []string{"get", "list", "watch"},
 				},
 			},
 		}

--- a/pkg/reconcilers/operator/discoveryservice/generators/role_test.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/role_test.go
@@ -7,6 +7,7 @@ import (
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,6 +67,11 @@ func TestGeneratorOptions_Role(t *testing.T) {
 						APIGroups: []string{marin3rv1alpha1.GroupVersion.Group},
 						Resources: []string{rbacv1.ResourceAll},
 						Verbs:     []string{rbacv1.VerbAll},
+					},
+					{
+						APIGroups: []string{discoveryv1.SchemeGroupVersion.Group},
+						Resources: []string{"endpointslices"},
+						Verbs:     []string{"get", "list", "watch"},
 					},
 				},
 			},

--- a/test/e2e/marin3r/discoveryservice_suite_test.go
+++ b/test/e2e/marin3r/discoveryservice_suite_test.go
@@ -36,10 +36,7 @@ var _ = Describe("DiscoveryService intall and lifecycle", func() {
 		n := &corev1.Namespace{}
 		Eventually(func() bool {
 			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: testNamespace}, n)
-			if err != nil {
-				return false
-			}
-			return true
+			return err == nil
 		}, timeout, poll).Should(BeTrue())
 
 		By("creating a DiscoveryService instance")
@@ -49,7 +46,7 @@ var _ = Describe("DiscoveryService intall and lifecycle", func() {
 				Namespace: testNamespace,
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceSpec{
-				Image: pointer.StringPtr(image),
+				Image: pointer.String(image),
 			},
 		}
 		err = k8sClient.Create(context.Background(), ds)
@@ -57,10 +54,7 @@ var _ = Describe("DiscoveryService intall and lifecycle", func() {
 		Eventually(func() bool {
 			key := types.NamespacedName{Name: "instance", Namespace: testNamespace}
 			err := k8sClient.Get(context.Background(), key, ds)
-			if err != nil {
-				return false
-			}
-			return true
+			return err == nil
 		}, timeout, poll).Should(BeTrue())
 
 	})
@@ -136,7 +130,7 @@ var _ = Describe("DiscoveryService intall and lifecycle", func() {
 		It("reconciles the discovery service deployment", func() {
 
 			patch := client.MergeFrom(ds.DeepCopy())
-			ds.Spec.Debug = pointer.BoolPtr(true)
+			ds.Spec.Debug = pointer.Bool(true)
 			generation := ds.GetGeneration()
 			err := k8sClient.Patch(context.Background(), ds, patch)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/marin3r/envoydeployment_suite_test.go
+++ b/test/e2e/marin3r/envoydeployment_suite_test.go
@@ -100,21 +100,11 @@ var _ = Describe("EnvoyDeployment", func() {
 			By("applying an EnvoyConfig that will configure the envoy Deployment through service discovery")
 			key := types.NamespacedName{Name: "envoyconfig", Namespace: testNamespace}
 			ec = testutil.GenerateEnvoyConfig(key, nodeID, envoy.APIv3,
-				func() []envoy.Resource {
-					return []envoy.Resource{}
-				},
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.ClusterWithStrictDNSV3("nginx", "nginx", 80)}
-				},
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.ProxyPassRouteV3("proxypass", "nginx")}
-				},
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.HTTPListener("http", "proxypass", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), nil)}
-				},
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.HTTPFilterRouter("router_filter")}
-				},
+				nil,
+				[]envoy.Resource{testutil.ClusterWithStrictDNSV3("nginx", "nginx", 80)},
+				[]envoy.Resource{testutil.ProxyPassRouteV3("proxypass", "nginx")},
+				[]envoy.Resource{testutil.HTTPListener("http", "proxypass", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), nil)},
+				[]envoy.Resource{testutil.HTTPFilterRouter("router_filter")},
 				nil,
 			)
 			Eventually(func() error {

--- a/test/e2e/marin3r/envoydeployment_suite_test.go
+++ b/test/e2e/marin3r/envoydeployment_suite_test.go
@@ -101,11 +101,12 @@ var _ = Describe("EnvoyDeployment", func() {
 			key := types.NamespacedName{Name: "envoyconfig", Namespace: testNamespace}
 			ec = testutil.GenerateEnvoyConfig(key, nodeID, envoy.APIv3,
 				nil,
-				[]envoy.Resource{testutil.ClusterWithStrictDNSV3("nginx", "nginx", 80)},
+				[]envoy.Resource{testutil.ClusterWithEdsV3("nginx")},
 				[]envoy.Resource{testutil.ProxyPassRouteV3("proxypass", "nginx")},
 				[]envoy.Resource{testutil.HTTPListener("http", "proxypass", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), nil)},
 				[]envoy.Resource{testutil.HTTPFilterRouter("router_filter")},
 				nil,
+				[]testutil.EndpointDiscovery{{ClusterName: "nginx", PortName: "http", LabelKey: "kubernetes.io/service-name", LabelValue: "nginx"}},
 			)
 			Eventually(func() error {
 				return k8sClient.Create(context.Background(), ec)

--- a/test/e2e/marin3r/pod_suite_test.go
+++ b/test/e2e/marin3r/pod_suite_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
@@ -54,7 +53,7 @@ var _ = Describe("Envoy pods", func() {
 				Namespace: testNamespace,
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceSpec{
-				Image: pointer.StringPtr(image),
+				Image: pointer.String(image),
 			},
 		}
 		err = k8sClient.Create(context.Background(), ds)
@@ -88,7 +87,7 @@ var _ = Describe("Envoy pods", func() {
 
 	Context("Envoy Pod with xDS configured", func() {
 		var pod *corev1.Pod
-		var ec *v1alpha1.EnvoyConfig
+		var ec *marin3rv1alpha1.EnvoyConfig
 		var localPort int
 		var nodeID string
 		var stopCh chan struct{}
@@ -110,6 +109,7 @@ var _ = Describe("Envoy pods", func() {
 				// Envoy listeners don't allow bind address changes
 				[]envoy.Resource{testutil.HTTPListener("http", "direct_response", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), nil)},
 				[]envoy.Resource{testutil.HTTPFilterRouter("router_filter")},
+				nil,
 				nil,
 			)
 
@@ -188,6 +188,7 @@ var _ = Describe("Envoy pods", func() {
 				[]envoy.Resource{testutil.HTTPListener("http", "direct_response", "router_filter", testutil.GetAddressV3("0.0.0.0", 30333), nil)},
 				[]envoy.Resource{testutil.HTTPFilterRouter("router_filter")},
 				nil,
+				nil,
 			).Spec
 			err := k8sClient.Patch(context.Background(), ec, patch)
 			Expect(err).ToNot(HaveOccurred())
@@ -240,6 +241,7 @@ var _ = Describe("Envoy pods", func() {
 						[]envoy.Resource{testutil.HTTPListener("https", "direct_response", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), testutil.TransportSocketV3("self-signed-cert"))},
 						[]envoy.Resource{testutil.HTTPFilterRouter("router_filter")},
 						[]string{"self-signed-cert"},
+						nil,
 					).Spec
 					err := k8sClient.Patch(context.Background(), ec, patch)
 					Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/marin3r/pod_suite_test.go
+++ b/test/e2e/marin3r/pod_suite_test.go
@@ -104,19 +104,14 @@ var _ = Describe("Envoy pods", func() {
 			By("applying an EnvoyConfig that configures the Pod with a direct response")
 			key := types.NamespacedName{Name: "test-envoyconfig", Namespace: testNamespace}
 			ec = testutil.GenerateEnvoyConfig(key, nodeID, envoy.APIv3,
-				func() []envoy.Resource { return nil },
-				func() []envoy.Resource { return nil },
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.DirectResponseRouteV3("direct_response", "OK")}
-				},
-				func() []envoy.Resource {
-					// Envoy listeners don't allow bind address changes
-					return []envoy.Resource{testutil.HTTPListener("http", "direct_response", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), nil)}
-				},
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.HTTPFilterRouter("router_filter")}
-				},
-				nil)
+				nil,
+				nil,
+				[]envoy.Resource{testutil.DirectResponseRouteV3("direct_response", "OK")},
+				// Envoy listeners don't allow bind address changes
+				[]envoy.Resource{testutil.HTTPListener("http", "direct_response", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), nil)},
+				[]envoy.Resource{testutil.HTTPFilterRouter("router_filter")},
+				nil,
+			)
 
 			Eventually(func() error {
 				return k8sClient.Create(context.Background(), ec)
@@ -186,18 +181,12 @@ var _ = Describe("Envoy pods", func() {
 			key := types.NamespacedName{Name: "test-envoyconfig", Namespace: testNamespace}
 			patch := client.MergeFrom(ec.DeepCopy())
 			ec.Spec = testutil.GenerateEnvoyConfig(key, nodeID, envoy.APIv3,
-				func() []envoy.Resource { return nil },
-				func() []envoy.Resource { return nil },
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.DirectResponseRouteV3("direct_response", "OK")}
-				},
-				func() []envoy.Resource {
-					// Envoy listeners don't allow bind address changes
-					return []envoy.Resource{testutil.HTTPListener("http", "direct_response", "router_filter", testutil.GetAddressV3("0.0.0.0", 30333), nil)}
-				},
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.HTTPFilterRouter("router_filter")}
-				},
+				nil,
+				nil,
+				[]envoy.Resource{testutil.DirectResponseRouteV3("direct_response", "OK")},
+				// Envoy listeners don't allow bind address changes
+				[]envoy.Resource{testutil.HTTPListener("http", "direct_response", "router_filter", testutil.GetAddressV3("0.0.0.0", 30333), nil)},
+				[]envoy.Resource{testutil.HTTPFilterRouter("router_filter")},
 				nil,
 			).Spec
 			err := k8sClient.Patch(context.Background(), ec, patch)
@@ -245,17 +234,11 @@ var _ = Describe("Envoy pods", func() {
 					key := types.NamespacedName{Name: "test-envoyconfig", Namespace: testNamespace}
 					patch := client.MergeFrom(ec.DeepCopy())
 					ec.Spec = testutil.GenerateEnvoyConfig(key, nodeID, envoy.APIv3,
-						func() []envoy.Resource { return nil },
-						func() []envoy.Resource { return nil },
-						func() []envoy.Resource {
-							return []envoy.Resource{testutil.DirectResponseRouteV3("direct_response", "OK")}
-						},
-						func() []envoy.Resource {
-							return []envoy.Resource{testutil.HTTPListener("https", "direct_response", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), testutil.TransportSocketV3("self-signed-cert"))}
-						},
-						func() []envoy.Resource {
-							return []envoy.Resource{testutil.HTTPFilterRouter("router_filter")}
-						},
+						nil,
+						nil,
+						[]envoy.Resource{testutil.DirectResponseRouteV3("direct_response", "OK")},
+						[]envoy.Resource{testutil.HTTPListener("https", "direct_response", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), testutil.TransportSocketV3("self-signed-cert"))},
+						[]envoy.Resource{testutil.HTTPFilterRouter("router_filter")},
 						[]string{"self-signed-cert"},
 					).Spec
 					err := k8sClient.Patch(context.Background(), ec, patch)

--- a/test/e2e/marin3r/sidecar_suite_test.go
+++ b/test/e2e/marin3r/sidecar_suite_test.go
@@ -101,21 +101,11 @@ var _ = Describe("Envoy sidecars", func() {
 			By("applaying an EnvoyConfig that will configure the envoy sidecar through service discovery")
 			key := types.NamespacedName{Name: "nginx-envoyconfig", Namespace: testNamespace}
 			ec = testutil.GenerateEnvoyConfig(key, nodeID, envoy.APIv3,
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.EndpointV3("nginx", "127.0.0.1", 80)}
-				},
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.ClusterWithEdsV3("nginx")}
-				},
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.ProxyPassRouteV3("proxypass", "nginx")}
-				},
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.HTTPListener("http", "proxypass", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), nil)}
-				},
-				func() []envoy.Resource {
-					return []envoy.Resource{testutil.HTTPFilterRouter("router_filter")}
-				},
+				[]envoy.Resource{testutil.EndpointV3("nginx", "127.0.0.1", 80)},
+				[]envoy.Resource{testutil.ClusterWithEdsV3("nginx")},
+				[]envoy.Resource{testutil.ProxyPassRouteV3("proxypass", "nginx")},
+				[]envoy.Resource{testutil.HTTPListener("http", "proxypass", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), nil)},
+				[]envoy.Resource{testutil.HTTPFilterRouter("router_filter")},
 				nil,
 			)
 

--- a/test/e2e/marin3r/sidecar_suite_test.go
+++ b/test/e2e/marin3r/sidecar_suite_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Envoy sidecars", func() {
 				Namespace: testNamespace,
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceSpec{
-				Image: pointer.StringPtr(image),
+				Image: pointer.String(image),
 			},
 		}
 		err = k8sClient.Create(context.Background(), ds)
@@ -106,6 +106,7 @@ var _ = Describe("Envoy sidecars", func() {
 				[]envoy.Resource{testutil.ProxyPassRouteV3("proxypass", "nginx")},
 				[]envoy.Resource{testutil.HTTPListener("http", "proxypass", "router_filter", testutil.GetAddressV3("0.0.0.0", envoyListenerPort), nil)},
 				[]envoy.Resource{testutil.HTTPFilterRouter("router_filter")},
+				nil,
 				nil,
 			)
 

--- a/test/e2e/marin3r/suite_test.go
+++ b/test/e2e/marin3r/suite_test.go
@@ -60,7 +60,7 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "e2e test suite")
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 
 	logger = ctrl.Log.WithName("e2e")
 
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func(done Done) {
 	nameGenerator = namegenerator.NewNameGenerator(seed)
 
 	testEnv = &envtest.Environment{
-		UseExistingCluster: pointer.BoolPtr(true),
+		UseExistingCluster: pointer.Bool(true),
 	}
 
 	var err error
@@ -84,7 +84,6 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
-	close(done)
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/util/generators.go
+++ b/test/e2e/util/generators.go
@@ -183,90 +183,8 @@ func GenerateTLSSecret(k8skey types.NamespacedName, commonName, duration string)
 	return secret, err
 }
 
-// func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy.APIVersion,
-// 	endpointsGenFn, clustersGenFn, routesGenFn, listenersGenFn, extensionConfigsGenFn func() []envoy.Resource,
-// 	secrets []string) *marin3rv1alpha1.EnvoyConfig {
-// 	m := envoy_serializer.NewResourceMarshaller(envoy_serializer.JSON, envoyAPI)
-
-// 	return &marin3rv1alpha1.EnvoyConfig{
-// 		ObjectMeta: metav1.ObjectMeta{
-// 			Name:      key.Name,
-// 			Namespace: key.Namespace,
-// 		},
-// 		Spec: marin3rv1alpha1.EnvoyConfigSpec{
-// 			EnvoyAPI: pointer.StringPtr(envoyAPI.String()),
-// 			NodeID:   nodeID,
-// 			EnvoyResources: &marin3rv1alpha1.EnvoyResources{
-// 				Endpoints: func() []marin3rv1alpha1.EnvoyResource {
-// 					endpoints := []marin3rv1alpha1.EnvoyResource{}
-// 					for _, resource := range endpointsGenFn() {
-// 						json, err := m.Marshal(resource)
-// 						if err != nil {
-// 							panic(err)
-// 						}
-// 						endpoints = append(endpoints, marin3rv1alpha1.EnvoyResource{Value: json})
-// 					}
-// 					return endpoints
-// 				}(),
-// 				Clusters: func() []marin3rv1alpha1.EnvoyResource {
-// 					clusters := []marin3rv1alpha1.EnvoyResource{}
-// 					for _, resource := range clustersGenFn() {
-// 						json, err := m.Marshal(resource)
-// 						if err != nil {
-// 							panic(err)
-// 						}
-// 						clusters = append(clusters, marin3rv1alpha1.EnvoyResource{Value: json})
-// 					}
-// 					return clusters
-// 				}(),
-// 				Routes: func() []marin3rv1alpha1.EnvoyResource {
-// 					routes := []marin3rv1alpha1.EnvoyResource{}
-// 					for _, resource := range routesGenFn() {
-// 						json, err := m.Marshal(resource)
-// 						if err != nil {
-// 							panic(err)
-// 						}
-// 						routes = append(routes, marin3rv1alpha1.EnvoyResource{Value: json})
-// 					}
-// 					return routes
-// 				}(),
-// 				Listeners: func() []marin3rv1alpha1.EnvoyResource {
-// 					listeners := []marin3rv1alpha1.EnvoyResource{}
-// 					for _, resource := range listenersGenFn() {
-// 						json, err := m.Marshal(resource)
-// 						if err != nil {
-// 							panic(err)
-// 						}
-// 						listeners = append(listeners, marin3rv1alpha1.EnvoyResource{Value: json})
-// 					}
-// 					return listeners
-// 				}(),
-// 				Secrets: func() []marin3rv1alpha1.EnvoySecretResource {
-// 					s := []marin3rv1alpha1.EnvoySecretResource{}
-// 					for _, name := range secrets {
-// 						s = append(s, marin3rv1alpha1.EnvoySecretResource{Name: name})
-// 					}
-// 					return s
-// 				}(),
-// 				ExtensionConfigs: func() []marin3rv1alpha1.EnvoyResource {
-// 					extensionConfigs := []marin3rv1alpha1.EnvoyResource{}
-// 					for _, resource := range extensionConfigsGenFn() {
-// 						json, err := m.Marshal(resource)
-// 						if err != nil {
-// 							panic(err)
-// 						}
-// 						extensionConfigs = append(extensionConfigs, marin3rv1alpha1.EnvoyResource{Value: json})
-// 					}
-// 					return extensionConfigs
-// 				}(),
-// 			},
-// 		},
-// 	}
-
-// }
-
 func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy.APIVersion,
-	endpointsGenFn, clustersGenFn, routesGenFn, listenersGenFn, extensionConfigsGenFn func() []envoy.Resource,
+	endpoints, clusters, routes, listeners, extension []envoy.Resource,
 	secrets []string) *marin3rv1alpha1.EnvoyConfig {
 	m := envoy_serializer.NewResourceMarshaller(envoy_serializer.JSON, envoyAPI)
 
@@ -284,7 +202,7 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 
 	resources := []marin3rv1alpha1.Resource{}
 
-	for _, resource := range endpointsGenFn() {
+	for _, resource := range endpoints {
 		json, err := m.Marshal(resource)
 		if err != nil {
 			panic(err)
@@ -293,7 +211,7 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 			Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension(json)})
 	}
 
-	for _, resource := range clustersGenFn() {
+	for _, resource := range clusters {
 		json, err := m.Marshal(resource)
 		if err != nil {
 			panic(err)
@@ -302,7 +220,7 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 			Type: string(envoy.Cluster), Value: k8sutil.StringtoRawExtension(json)})
 	}
 
-	for _, resource := range routesGenFn() {
+	for _, resource := range routes {
 		json, err := m.Marshal(resource)
 		if err != nil {
 			panic(err)
@@ -311,7 +229,7 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 			Type: string(envoy.Route), Value: k8sutil.StringtoRawExtension(json)})
 	}
 
-	for _, resource := range listenersGenFn() {
+	for _, resource := range listeners {
 		json, err := m.Marshal(resource)
 		if err != nil {
 			panic(err)
@@ -327,7 +245,7 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 		})
 	}
 
-	for _, resource := range extensionConfigsGenFn() {
+	for _, resource := range extension {
 		json, err := m.Marshal(resource)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
# Description

With this PR, the discovery service gains the ability to discover and feed a list of Pod IPs to a subscribed consumer. The endpoints are discovered by watching the EndpointSlices resources in the namespace that match a given label selector.

An endpoint resource would have to be declared like

```yaml
    - type: endpoint
      generateFromEndpointSlices:
        selector:
          matchLabels:
            kubernetes.io/service-name: test
        clusterName: test
        targetPort: http
```

This would make the discovery service watch the EndpointSlices generated by the k8s Service named `test`. Any other custom label selector can be used.

The (debug) logs in the discovery service show how the list of pod IPs is generated and feed to consumers:

```
2023-05-10T10:41:29Z	DEBUG	setup.xds.cache.v3	respond type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment[kuard] version "58f6d94cd" with version "57f9787477"
2023-05-10T10:41:29Z	DEBUG	setup.xds.server.v3	Discovery Response	{"TypeURL": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment", "NodeID": "kuard", "StreamID": 1, "Version": "57f9787477", "Resources": ["{\"@type\":\"type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment\",\"cluster_name\":\"kuard\",\"endpoints\":[{\"lb_endpoints\":[{\"endpoint\":{\"address\":{\"socket_address\":{\"address\":\"10.244.0.14\",\"port_value\":8080}}},\"health_status\":\"HEALTHY\"},{\"endpoint\":{\"address\":{\"socket_address\":{\"address\":\"10.244.0.20\",\"port_value\":8080}}},\"health_status\":\"DRAINING\"}]}]}"], "Pod": "marin3r-envoydeployment-kuard-7578497bb-bbpdn"}
```

The health status of each endpoint is provided so the consumer can make appropriate load balancing decisions.

/kind feature
/priority important-soon
/assign

This PR depends on #177 being merged first.

# How to test

`make kind-create`
`export KUBECONFIG=${PWD}/kubeconfig`
`kubectl apply -f examples/e2e/deployment`

Check the logs of the discovery service and the endpoint pod in the `default` namespace to see how the list of endpoints is updated each time the number of replicas in the nginx deployment is changed.