### PR TITLE
Use generic pointer function to make life easier

### DIFF
--- a/apis/marin3r/v1alpha1/envoyconfig_types.go
+++ b/apis/marin3r/v1alpha1/envoyconfig_types.go
@@ -62,15 +62,15 @@ type EnvoyConfigSpec struct {
 	NodeID string `json:"nodeID"`
 	// Serialization specicifies the serialization format used to describe the resources. "json" and "yaml"
 	// are supported. "json" is used if unset.
-	// +kubebuilder:validation:Enum=json;b64json;yaml
+	// +kubebuilder:validation:Enum=json;yaml
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
-	Serialization *string `json:"serialization,omitempty"`
+	Serialization *envoy_serializer.Serialization `json:"serialization,omitempty"`
 	// EnvoyAPI is the version of envoy's API to use. Defaults to v3.
 	// +kubebuilder:validation:Enum=v3
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
-	EnvoyAPI *string `json:"envoyAPI,omitempty"`
+	EnvoyAPI *envoy.APIVersion `json:"envoyAPI,omitempty"`
 	// EnvoyResources holds the different types of resources suported by the envoy discovery service
 	// DEPRECATED. Use the `resources` field instead.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/apis/marin3r/v1alpha1/envoyconfig_types_test.go
+++ b/apis/marin3r/v1alpha1/envoyconfig_types_test.go
@@ -23,9 +23,9 @@ import (
 	reconcilerutil "github.com/3scale-ops/basereconciler/util"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 )
 
 func TestEnvoyConfig_GetEnvoyAPIVersion(t *testing.T) {
@@ -44,7 +44,7 @@ func TestEnvoyConfig_GetEnvoyAPIVersion(t *testing.T) {
 			func() *EnvoyConfig {
 				return &EnvoyConfig{
 					Spec: EnvoyConfigSpec{
-						EnvoyAPI: pointer.StringPtr("v3"),
+						EnvoyAPI: pointer.New(envoy.APIv3),
 					},
 				}
 			},
@@ -78,7 +78,7 @@ func TestEnvoyConfig_GetSerialization(t *testing.T) {
 			func() *EnvoyConfig {
 				return &EnvoyConfig{
 					Spec: EnvoyConfigSpec{
-						Serialization: pointer.StringPtr("yaml"),
+						Serialization: pointer.New(envoy_serializer.YAML),
 					},
 				}
 			},

--- a/apis/marin3r/v1alpha1/envoyconfig_webhook.go
+++ b/apis/marin3r/v1alpha1/envoyconfig_webhook.go
@@ -91,7 +91,7 @@ func (r *EnvoyConfig) ValidateResources() error {
 
 		switch res.Type {
 
-		case string(envoy.Secret):
+		case envoy.Secret:
 			if res.GenerateFromTlsSecret == nil {
 				errList = append(errList, fmt.Errorf("'generateFromTlsSecret' cannot be empty for type '%s'", envoy.Secret))
 			}
@@ -102,7 +102,7 @@ func (r *EnvoyConfig) ValidateResources() error {
 				errList = append(errList, fmt.Errorf("'generateFromEndpointSlice' can only be used type '%s'", envoy.Endpoint))
 			}
 
-		case string(envoy.Endpoint):
+		case envoy.Endpoint:
 			if res.GenerateFromEndpointSlices != nil && res.Value != nil {
 				errList = append(errList, fmt.Errorf("only one of 'generateFromEndpointSlice', 'value' allowed for type '%s'", envoy.Secret))
 			}

--- a/apis/marin3r/v1alpha1/envoyconfig_webhook_test.go
+++ b/apis/marin3r/v1alpha1/envoyconfig_webhook_test.go
@@ -19,9 +19,11 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/3scale-ops/marin3r/pkg/envoy"
+	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
 )
 
 func TestEnvoyConfig_ValidateResources(t *testing.T) {
@@ -80,7 +82,7 @@ func TestEnvoyConfig_ValidateResources(t *testing.T) {
 						Value: &runtime.RawExtension{
 							Raw: []byte(`{"name": "cluster"}`),
 						},
-						Blueprint: new(string),
+						Blueprint: new(Blueprint),
 					}},
 				},
 			}, wantErr: true,
@@ -224,7 +226,7 @@ func TestEnvoyConfig_ValidateResources(t *testing.T) {
 					NodeID: "test",
 					Resources: []Resource{{
 						Type:      "endpoint",
-						Blueprint: new(string),
+						Blueprint: new(Blueprint),
 					}},
 				},
 			}, wantErr: true,
@@ -256,11 +258,11 @@ func TestEnvoyConfig_ValidateEnvoyResources(t *testing.T) {
 			fields: fields{
 				Spec: EnvoyConfigSpec{
 					NodeID:        "test",
-					Serialization: pointer.String("json"),
-					EnvoyAPI:      pointer.String("v3"),
+					Serialization: pointer.New(envoy_serializer.JSON),
+					EnvoyAPI:      pointer.New(envoy.APIv3),
 					EnvoyResources: &EnvoyResources{
 						Clusters: []EnvoyResource{{
-							Name: pointer.String("cluster"),
+							Name: pointer.New("cluster"),
 							// the connect_timeout value unit is wrong
 							Value: `{"name":"cluster1","type":"STRICT_DNS","connect_timeout":"2xs","load_assignment":{"cluster_name":"cluster1"}}`,
 						}},
@@ -274,11 +276,11 @@ func TestEnvoyConfig_ValidateEnvoyResources(t *testing.T) {
 			fields: fields{
 				Spec: EnvoyConfigSpec{
 					NodeID:        "test",
-					Serialization: pointer.String("yaml"),
-					EnvoyAPI:      pointer.String("v3"),
+					Serialization: pointer.New(envoy_serializer.YAML),
+					EnvoyAPI:      pointer.New(envoy.APIv3),
 					EnvoyResources: &EnvoyResources{
 						Listeners: []EnvoyResource{{
-							Name: pointer.String("test"),
+							Name: pointer.New("test"),
 							// the "port" property should be "port_value"
 							Value: `
                               name: listener1
@@ -328,7 +330,7 @@ func TestEnvoyConfig_Validate(t *testing.T) {
 					NodeID: "test",
 					EnvoyResources: &EnvoyResources{
 						Clusters: []EnvoyResource{{
-							Name:  pointer.String("cluster"),
+							Name:  pointer.New("cluster"),
 							Value: `{"name":"cluster1","type":"STRICT_DNS","connect_timeout":"2s","load_assignment":{"cluster_name":"cluster1"}}`,
 						}},
 					},

--- a/apis/marin3r/v1alpha1/envoyconfigrevision_types.go
+++ b/apis/marin3r/v1alpha1/envoyconfigrevision_types.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"github.com/3scale-ops/marin3r/pkg/envoy"
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -58,13 +57,13 @@ type EnvoyConfigRevisionSpec struct {
 	// +kubebuilder:validation:Enum=v3
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
-	EnvoyAPI *string `json:"envoyAPI,omitempty"`
+	EnvoyAPI *envoy.APIVersion `json:"envoyAPI,omitempty"`
 	// Serialization specicifies the serialization format used to describe the resources. "json" and "yaml"
 	// are supported. "json" is used if unset.
 	// +kubebuilder:validation:Enum=json;b64json;yaml
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
-	Serialization *string `json:"serialization,omitempty"`
+	Serialization *envoy_serializer.Serialization `json:"serialization,omitempty"`
 	// EnvoyResources holds the different types of resources suported by the envoy discovery service
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional

--- a/apis/marin3r/v1alpha1/envoyconfigrevision_types_test.go
+++ b/apis/marin3r/v1alpha1/envoyconfigrevision_types_test.go
@@ -21,7 +21,7 @@ import (
 
 	envoy "github.com/3scale-ops/marin3r/pkg/envoy"
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
-	"k8s.io/utils/pointer"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 )
 
 func TestEnvoyConfigRevisionStatus_IsPublished(t *testing.T) {
@@ -40,7 +40,7 @@ func TestEnvoyConfigRevisionStatus_IsPublished(t *testing.T) {
 			func() *EnvoyConfigRevision {
 				return &EnvoyConfigRevision{
 					Status: EnvoyConfigRevisionStatus{
-						Published: pointer.BoolPtr(true),
+						Published: pointer.New(true),
 					},
 				}
 			},
@@ -74,7 +74,7 @@ func TestEnvoyConfigRevisionStatus_IsTainted(t *testing.T) {
 			func() *EnvoyConfigRevision {
 				return &EnvoyConfigRevision{
 					Status: EnvoyConfigRevisionStatus{
-						Tainted: pointer.BoolPtr(true),
+						Tainted: pointer.New(true),
 					},
 				}
 			},
@@ -108,7 +108,7 @@ func TestEnvoyConfigRevision_GetEnvoyAPIVersion(t *testing.T) {
 			func() *EnvoyConfigRevision {
 				return &EnvoyConfigRevision{
 					Spec: EnvoyConfigRevisionSpec{
-						EnvoyAPI: pointer.StringPtr("v3"),
+						EnvoyAPI: pointer.New(envoy.APIv3),
 					},
 				}
 			},
@@ -142,7 +142,7 @@ func TestEnvoyConfigRevision_GetSerialization(t *testing.T) {
 			func() *EnvoyConfigRevision {
 				return &EnvoyConfigRevision{
 					Spec: EnvoyConfigRevisionSpec{
-						Serialization: pointer.StringPtr("yaml"),
+						Serialization: pointer.New(envoy_serializer.YAML),
 					},
 				}
 			},

--- a/apis/marin3r/v1alpha1/resources.go
+++ b/apis/marin3r/v1alpha1/resources.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/3scale-ops/marin3r/pkg/envoy"
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 )
 
@@ -30,7 +30,7 @@ type Resource struct {
 	// Type is the type url for the protobuf message
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:validation:Enum=listener;route;scopedRoute;cluster;endpoint;secret;runtime;extensionConfig;
-	Type string `json:"type"`
+	Type envoy.Type `json:"type"`
 	// Value is the protobufer message that configures the resource. The proto
 	// must match the envoy configuration API v3 specification for the given resource
 	// type (https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#resource-types)
@@ -51,7 +51,7 @@ type Resource struct {
 	// +kubebuilder:validation:Enum=tlsCertificate;validationContext;
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
-	Blueprint *string `json:"blueprint,omitempty"`
+	Blueprint *Blueprint `json:"blueprint,omitempty"`
 }
 
 type GenerateFromEndpointSlices struct {
@@ -150,9 +150,9 @@ func (in *EnvoyResources) Resources(serialization envoy_serializer.Serialization
 	}
 	for _, deprecatedResource := range in.Secrets {
 		r := Resource{
-			Type:                  string(envoy.Secret),
+			Type:                  envoy.Secret,
 			GenerateFromTlsSecret: &deprecatedResource.Name,
-			Blueprint:             pointer.String(string(TlsCertificate)),
+			Blueprint:             pointer.New(TlsCertificate),
 		}
 		resources = append(resources, r)
 	}
@@ -195,7 +195,7 @@ func (res *EnvoyResource) Resource(rType envoy.Type, serialization envoy_seriali
 	}
 
 	return Resource{
-		Type: string(rType),
+		Type: rType,
 		Value: &runtime.RawExtension{
 			Raw: b,
 		},

--- a/apis/marin3r/v1alpha1/resources_test.go
+++ b/apis/marin3r/v1alpha1/resources_test.go
@@ -6,7 +6,7 @@ import (
 
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
 	k8sutil "github.com/3scale-ops/marin3r/pkg/util/k8s"
-	"k8s.io/utils/pointer"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 )
 
 func TestEnvoyResources_Resources(t *testing.T) {
@@ -49,7 +49,7 @@ func TestEnvoyResources_Resources(t *testing.T) {
 			want: []Resource{
 				{Type: "endpoint", Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
 				{Type: "cluster", Value: k8sutil.StringtoRawExtension("{\"name\": \"cluster\"}")},
-				{Type: "secret", GenerateFromTlsSecret: pointer.String("secret"), Blueprint: pointer.String(string(TlsCertificate))},
+				{Type: "secret", GenerateFromTlsSecret: pointer.New("secret"), Blueprint: pointer.New(TlsCertificate)},
 			},
 			wantErr: false,
 		},
@@ -72,7 +72,7 @@ func TestEnvoyResources_Resources(t *testing.T) {
 			want: []Resource{
 				{Type: "endpoint", Value: k8sutil.StringtoRawExtension("{\"cluster_name\":\"endpoint\"}")},
 				{Type: "cluster", Value: k8sutil.StringtoRawExtension("{\"name\":\"cluster\"}")},
-				{Type: "secret", GenerateFromTlsSecret: pointer.String("secret"), Blueprint: pointer.String(string(TlsCertificate))},
+				{Type: "secret", GenerateFromTlsSecret: pointer.New("secret"), Blueprint: pointer.New(TlsCertificate)},
 			},
 			wantErr: false,
 		},

--- a/apis/marin3r/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/marin3r/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/3scale-ops/marin3r/pkg/envoy"
+	serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -166,12 +168,12 @@ func (in *EnvoyConfigRevisionSpec) DeepCopyInto(out *EnvoyConfigRevisionSpec) {
 	*out = *in
 	if in.EnvoyAPI != nil {
 		in, out := &in.EnvoyAPI, &out.EnvoyAPI
-		*out = new(string)
+		*out = new(envoy.APIVersion)
 		**out = **in
 	}
 	if in.Serialization != nil {
 		in, out := &in.Serialization, &out.Serialization
-		*out = new(string)
+		*out = new(serializer.Serialization)
 		**out = **in
 	}
 	if in.EnvoyResources != nil {
@@ -244,12 +246,12 @@ func (in *EnvoyConfigSpec) DeepCopyInto(out *EnvoyConfigSpec) {
 	*out = *in
 	if in.Serialization != nil {
 		in, out := &in.Serialization, &out.Serialization
-		*out = new(string)
+		*out = new(serializer.Serialization)
 		**out = **in
 	}
 	if in.EnvoyAPI != nil {
 		in, out := &in.EnvoyAPI, &out.EnvoyAPI
-		*out = new(string)
+		*out = new(envoy.APIVersion)
 		**out = **in
 	}
 	if in.EnvoyResources != nil {
@@ -469,7 +471,7 @@ func (in *Resource) DeepCopyInto(out *Resource) {
 	}
 	if in.Blueprint != nil {
 		in, out := &in.Blueprint, &out.Blueprint
-		*out = new(string)
+		*out = new(Blueprint)
 		**out = **in
 	}
 }

--- a/apis/operator.marin3r/v1alpha1/discoveryservice_types_test.go
+++ b/apis/operator.marin3r/v1alpha1/discoveryservice_types_test.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"github.com/3scale-ops/marin3r/pkg/image"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestDiscoveryService_Resources(t *testing.T) {
@@ -271,7 +271,7 @@ func TestDiscoveryService_GetImage(t *testing.T) {
 			func() *DiscoveryService {
 				return &DiscoveryService{
 					Spec: DiscoveryServiceSpec{
-						Image: pointer.StringPtr("image:test"),
+						Image: pointer.New("image:test"),
 					},
 				}
 			},
@@ -305,7 +305,7 @@ func TestDiscoveryService_Debug(t *testing.T) {
 			func() *DiscoveryService {
 				return &DiscoveryService{
 					Spec: DiscoveryServiceSpec{
-						Debug: pointer.BoolPtr(true),
+						Debug: pointer.New(true),
 					},
 				}
 			},

--- a/apis/operator.marin3r/v1alpha1/discoveryservicecertificate_types_test.go
+++ b/apis/operator.marin3r/v1alpha1/discoveryservicecertificate_types_test.go
@@ -19,8 +19,8 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/utils/pointer"
 )
 
 func TestDiscoveryServiceCertificate_IsServerCertificate(t *testing.T) {
@@ -39,7 +39,7 @@ func TestDiscoveryServiceCertificate_IsServerCertificate(t *testing.T) {
 			func() *DiscoveryServiceCertificate {
 				return &DiscoveryServiceCertificate{
 					Spec: DiscoveryServiceCertificateSpec{
-						IsServerCertificate: pointer.BoolPtr(true),
+						IsServerCertificate: pointer.New(true),
 					},
 				}
 			},
@@ -73,7 +73,7 @@ func TestDiscoveryServiceCertificate_IsCA(t *testing.T) {
 			func() *DiscoveryServiceCertificate {
 				return &DiscoveryServiceCertificate{
 					Spec: DiscoveryServiceCertificateSpec{
-						IsCA: pointer.BoolPtr(true),
+						IsCA: pointer.New(true),
 					},
 				}
 			},
@@ -175,7 +175,7 @@ func TestDiscoveryServiceCertificateStatus_IsReady(t *testing.T) {
 			func() *DiscoveryServiceCertificate {
 				return &DiscoveryServiceCertificate{
 					Status: DiscoveryServiceCertificateStatus{
-						Ready: pointer.BoolPtr(true),
+						Ready: pointer.New(true),
 					},
 				}
 			},
@@ -209,7 +209,7 @@ func TestDiscoveryServiceCertificateStatus_GetCertificateHash(t *testing.T) {
 			func() *DiscoveryServiceCertificate {
 				return &DiscoveryServiceCertificate{
 					Status: DiscoveryServiceCertificateStatus{
-						CertificateHash: pointer.StringPtr("xxxx"),
+						CertificateHash: pointer.New("xxxx"),
 					},
 				}
 			},

--- a/apis/operator.marin3r/v1alpha1/envoydeployment_types.go
+++ b/apis/operator.marin3r/v1alpha1/envoydeployment_types.go
@@ -21,11 +21,11 @@ import (
 	"time"
 
 	defaults "github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 const (
@@ -175,7 +175,7 @@ func (ed *EnvoyDeployment) AdminAccessLogPath() string {
 
 func (ed *EnvoyDeployment) Replicas() ReplicasSpec {
 	if ed.Spec.Replicas == nil {
-		return ReplicasSpec{Static: pointer.Int32Ptr(DefaultReplicas)}
+		return ReplicasSpec{Static: pointer.New(DefaultReplicas)}
 	}
 	if ed.Spec.Replicas.Static != nil {
 		return ReplicasSpec{Static: ed.Spec.Replicas.Static}

--- a/apis/operator.marin3r/v1alpha1/envoydeployment_types_test.go
+++ b/apis/operator.marin3r/v1alpha1/envoydeployment_types_test.go
@@ -1,4 +1,4 @@
-/*
+/*v1alpha1
 
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	defaults "github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 func TestEnvoyDeployment_Image(t *testing.T) {
@@ -45,7 +45,7 @@ func TestEnvoyDeployment_Image(t *testing.T) {
 		{"With explicitly set options",
 			func() *EnvoyDeployment {
 				return &EnvoyDeployment{
-					Spec: EnvoyDeploymentSpec{Image: pointer.StringPtr("image:test")},
+					Spec: EnvoyDeploymentSpec{Image: pointer.New("image:test")},
 				}
 			},
 			"image:test",
@@ -187,7 +187,7 @@ func TestEnvoyDeployment_AdminAccessLogPath(t *testing.T) {
 		{"With explicitly set options",
 			func() *EnvoyDeployment {
 				return &EnvoyDeployment{
-					Spec: EnvoyDeploymentSpec{AdminAccessLogPath: pointer.StringPtr("/my/log/file")},
+					Spec: EnvoyDeploymentSpec{AdminAccessLogPath: pointer.New("/my/log/file")},
 				}
 			},
 			"/my/log/file",
@@ -214,7 +214,7 @@ func TestEnvoyDeployment_Replicas(t *testing.T) {
 			func() *EnvoyDeployment {
 				return &EnvoyDeployment{}
 			},
-			ReplicasSpec{Static: pointer.Int32Ptr(DefaultReplicas)},
+			ReplicasSpec{Static: pointer.New(DefaultReplicas)},
 		},
 		{"With explicitly set options",
 			func() *EnvoyDeployment {
@@ -232,13 +232,13 @@ func TestEnvoyDeployment_Replicas(t *testing.T) {
 			func() *EnvoyDeployment {
 				return &EnvoyDeployment{
 					Spec: EnvoyDeploymentSpec{Replicas: &ReplicasSpec{
-						Static:  pointer.Int32Ptr(3),
+						Static:  pointer.New(int32(3)),
 						Dynamic: &DynamicReplicasSpec{},
 					}},
 				}
 			},
 			ReplicasSpec{
-				Static: pointer.Int32Ptr(3),
+				Static: pointer.New(int32(3)),
 			},
 		},
 	}
@@ -419,7 +419,7 @@ func TestInitManager_GetImage(t *testing.T) {
 		},
 		{
 			name:   "returns value",
-			fields: fields{Image: pointer.StringPtr("test")},
+			fields: fields{Image: pointer.New("test")},
 			want:   "test",
 		},
 	}
@@ -450,7 +450,7 @@ func TestShutdownManager_GetDrainTime(t *testing.T) {
 		{
 			name: "Returns value",
 			fields: fields{
-				DrainTime: pointer.Int64(100),
+				DrainTime: pointer.New(int64(100)),
 			},
 			want: 100,
 		},

--- a/apis/operator.marin3r/v1alpha1/envoydeployment_webhook_suite_test.go
+++ b/apis/operator.marin3r/v1alpha1/envoydeployment_webhook_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -27,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -83,9 +83,9 @@ var _ = Describe("EnvoyDeployment webhook", func() {
 					EnvoyConfigRef:      "test",
 					DiscoveryServiceRef: "test",
 					Replicas: &ReplicasSpec{
-						Static: pointer.Int32Ptr(5),
+						Static: pointer.New(int32(5)),
 						Dynamic: &DynamicReplicasSpec{
-							MinReplicas: pointer.Int32Ptr(2),
+							MinReplicas: pointer.New(int32(2)),
 							MaxReplicas: 10,
 						},
 					},

--- a/config/crd/bases/marin3r.3scale.net_envoyconfigs.yaml
+++ b/config/crd/bases/marin3r.3scale.net_envoyconfigs.yaml
@@ -374,7 +374,6 @@ spec:
                   is used if unset.
                 enum:
                 - json
-                - b64json
                 - yaml
                 type: string
             required:

--- a/controllers/marin3r/envoyconfig_controller_suite_test.go
+++ b/controllers/marin3r/envoyconfig_controller_suite_test.go
@@ -10,6 +10,7 @@ import (
 	xdss_v3 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v3"
 	envoy "github.com/3scale-ops/marin3r/pkg/envoy"
 	k8sutil "github.com/3scale-ops/marin3r/pkg/util/k8s"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	testutil "github.com/3scale-ops/marin3r/pkg/util/test"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	. "github.com/onsi/ginkgo/v2"
@@ -19,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -77,10 +77,10 @@ var _ = Describe("EnvoyConfig controller", func() {
 			ec = &marin3rv1alpha1.EnvoyConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: namespace},
 				Spec: marin3rv1alpha1.EnvoyConfigSpec{
-					EnvoyAPI: pointer.StringPtr("v3"),
+					EnvoyAPI: pointer.New(envoy.APIv3),
 					NodeID:   nodeID,
 					Resources: []marin3rv1alpha1.Resource{
-						{Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
+						{Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
 					}},
 			}
 			err := k8sClient.Create(context.Background(), ec)
@@ -142,10 +142,10 @@ var _ = Describe("EnvoyConfig controller", func() {
 			ec = &marin3rv1alpha1.EnvoyConfig{
 				ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: namespace},
 				Spec: marin3rv1alpha1.EnvoyConfigSpec{
-					EnvoyAPI: pointer.StringPtr("v3"),
+					EnvoyAPI: pointer.New(envoy.APIv3),
 					NodeID:   nodeID,
 					Resources: []marin3rv1alpha1.Resource{
-						{Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
+						{Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
 					}},
 			}
 			err := k8sClient.Create(context.Background(), ec)
@@ -170,7 +170,7 @@ var _ = Describe("EnvoyConfig controller", func() {
 				By("updating the EnvoyConfig with a wrong envoy v3 resource")
 				patch := client.MergeFrom(ec.DeepCopy())
 				ec.Spec.Resources = []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension("{\"wrong_key\": \"wrong_value\"}")},
+					{Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension("{\"wrong_key\": \"wrong_value\"}")},
 				}
 				err := k8sClient.Patch(context.Background(), ec, patch)
 				Expect(err).ToNot(HaveOccurred())
@@ -198,7 +198,7 @@ var _ = Describe("EnvoyConfig controller", func() {
 					By("updating again the EnvoyConfig with a correct envoy v3 resource")
 					patch := client.MergeFrom(ec.DeepCopy())
 					ec.Spec.Resources = []marin3rv1alpha1.Resource{
-						{Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"correct_endpoint\"}")},
+						{Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"correct_endpoint\"}")},
 					}
 					err := k8sClient.Patch(context.Background(), ec, patch)
 					Expect(err).ToNot(HaveOccurred())
@@ -267,7 +267,7 @@ var _ = Describe("EnvoyConfig controller", func() {
 					By("updating again the EnvoyConfig with a correct envoy v3 resource")
 					patch := client.MergeFrom(ec.DeepCopy())
 					ec.Spec.Resources = []marin3rv1alpha1.Resource{
-						{Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"correct_endpoint\"}")},
+						{Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"correct_endpoint\"}")},
 					}
 					err := k8sClient.Patch(context.Background(), ec, patch)
 					Expect(err).ToNot(HaveOccurred())

--- a/controllers/marin3r/envoyconfigrevision_controller.go
+++ b/controllers/marin3r/envoyconfigrevision_controller.go
@@ -29,6 +29,7 @@ import (
 	envoy_resources "github.com/3scale-ops/marin3r/pkg/envoy/resources"
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
 	envoyconfigrevision "github.com/3scale-ops/marin3r/pkg/reconcilers/marin3r/envoyconfigrevision"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -38,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -175,7 +175,7 @@ func (r *EnvoyConfigRevisionReconciler) taintSelf(ctx context.Context, ecr *mari
 			Reason:  reason,
 			Message: msg,
 		})
-		ecr.Status.Tainted = pointer.Bool(true)
+		ecr.Status.Tainted = pointer.New(true)
 
 		if err := r.Client.Status().Patch(ctx, ecr, patch); err != nil {
 			return err
@@ -236,7 +236,7 @@ func (r *EnvoyConfigRevisionReconciler) SecretsEventHandler() handler.EventHandl
 				if meta.IsStatusConditionTrue(ecr.Status.Conditions, marin3rv1alpha1.RevisionPublishedCondition) {
 					// check if the k8s Secret is relevant for this EnvoyConfigRevision
 					for _, s := range ecr.Spec.Resources {
-						if s.Type == string(envoy.Secret) {
+						if s.Type == envoy.Secret {
 
 							if *s.GenerateFromTlsSecret == secret.GetName() {
 								reconcileRequests = append(reconcileRequests,
@@ -274,7 +274,7 @@ func (r *EnvoyConfigRevisionReconciler) EndpointSlicesEventHandler() handler.Eve
 				if meta.IsStatusConditionTrue(ecr.Status.Conditions, marin3rv1alpha1.RevisionPublishedCondition) {
 					// check if the k8s EndpointSlice is relevant for this EnvoyConfigRevision
 					for _, r := range ecr.Spec.Resources {
-						if r.Type == string(envoy.Endpoint) && r.GenerateFromEndpointSlices != nil {
+						if r.Type == envoy.Endpoint && r.GenerateFromEndpointSlices != nil {
 
 							selector, err := metav1.LabelSelectorAsSelector(r.GenerateFromEndpointSlices.Selector)
 							if err != nil {

--- a/controllers/marin3r/envoyconfigrevision_controller_suite_test.go
+++ b/controllers/marin3r/envoyconfigrevision_controller_suite_test.go
@@ -10,6 +10,7 @@ import (
 	xdss_v3 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v3"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
 	k8sutil "github.com/3scale-ops/marin3r/pkg/util/k8s"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	testutil "github.com/3scale-ops/marin3r/pkg/util/test"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -21,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -81,9 +81,9 @@ var _ = Describe("EnvoyConfigRevision controller", func() {
 				Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
 					NodeID:   nodeID,
 					Version:  "xxxx",
-					EnvoyAPI: pointer.String(string(envoy.APIv3)),
+					EnvoyAPI: pointer.New(envoy.APIv3),
 					Resources: []marin3rv1alpha1.Resource{
-						{Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension(`{"cluster_name": "endpoint"}`)},
+						{Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension(`{"cluster_name": "endpoint"}`)},
 					}},
 			}
 			err := k8sClient.Create(context.Background(), ecr)
@@ -162,9 +162,9 @@ var _ = Describe("EnvoyConfigRevision controller", func() {
 				Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
 					NodeID:   nodeID,
 					Version:  "xxxx",
-					EnvoyAPI: pointer.String(string(envoy.APIv3)),
+					EnvoyAPI: pointer.New(envoy.APIv3),
 					Resources: []marin3rv1alpha1.Resource{
-						{Type: string(envoy.Secret), GenerateFromTlsSecret: pointer.String("secret")},
+						{Type: envoy.Secret, GenerateFromTlsSecret: pointer.New("secret")},
 					},
 				},
 			}
@@ -266,7 +266,7 @@ var _ = Describe("EnvoyConfigRevision controller", func() {
 					NodeID:  nodeID,
 					Version: "xxxx",
 					Resources: []marin3rv1alpha1.Resource{
-						{Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
+						{Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
 					}},
 			}
 			err := k8sClient.Create(context.Background(), ecr)
@@ -329,7 +329,7 @@ var _ = Describe("EnvoyConfigRevision controller", func() {
 					NodeID:  nodeID,
 					Version: "xxxx",
 					Resources: []marin3rv1alpha1.Resource{
-						{Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
+						{Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
 					}},
 			}
 			err := k8sClient.Create(context.Background(), ecr)
@@ -393,7 +393,7 @@ var _ = Describe("EnvoyConfigRevision controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 				patch := client.MergeFrom(ecr.DeepCopy())
 				ecr.Spec.Resources = []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Cluster), Value: k8sutil.StringtoRawExtension("{\"wrong_key\": \"wrong_value\"}")},
+					{Type: envoy.Cluster, Value: k8sutil.StringtoRawExtension("{\"wrong_key\": \"wrong_value\"}")},
 				}
 				err = k8sClient.Patch(context.Background(), ecr, patch)
 				Expect(err).ToNot(HaveOccurred())
@@ -423,7 +423,7 @@ var _ = Describe("EnvoyConfigRevision controller", func() {
 				err := k8sClient.Get(context.Background(), key, ecr)
 				Expect(err).ToNot(HaveOccurred())
 				patch := client.MergeFrom(ecr.DeepCopy())
-				ecr.Spec.Resources = []marin3rv1alpha1.Resource{{Type: string(envoy.Secret), GenerateFromTlsSecret: pointer.String("secret")}}
+				ecr.Spec.Resources = []marin3rv1alpha1.Resource{{Type: envoy.Secret, GenerateFromTlsSecret: pointer.New("secret")}}
 				err = k8sClient.Patch(context.Background(), ecr, patch)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/marin3r/envoyconfigrevision_controller_test.go
+++ b/controllers/marin3r/envoyconfigrevision_controller_test.go
@@ -7,12 +7,12 @@ import (
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	xdss_v3 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v3"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -66,7 +66,7 @@ func Test_filterByAPIVersion(t *testing.T) {
 				obj: &marin3rv1alpha1.EnvoyConfigRevision{
 					ObjectMeta: metav1.ObjectMeta{Name: "xx", Namespace: "xx"},
 					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
-						EnvoyAPI: pointer.StringPtr(string(envoy.APIv3)),
+						EnvoyAPI: pointer.New(envoy.APIv3),
 					},
 				},
 				version: envoy.APIv3,
@@ -79,7 +79,7 @@ func Test_filterByAPIVersion(t *testing.T) {
 				obj: &marin3rv1alpha1.EnvoyConfigRevision{
 					ObjectMeta: metav1.ObjectMeta{Name: "xx", Namespace: "xx"},
 					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
-						EnvoyAPI: pointer.StringPtr("XX"),
+						EnvoyAPI: pointer.New(envoy.APIVersion("XX")),
 					},
 				},
 				version: envoy.APIv3,

--- a/controllers/operator.marin3r/discoveryservice_controller_suite_test.go
+++ b/controllers/operator.marin3r/discoveryservice_controller_suite_test.go
@@ -6,6 +6,7 @@ import (
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	"github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -14,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -47,7 +47,7 @@ var _ = Describe("DiscoveryService controller", func() {
 				Namespace: namespace,
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceSpec{
-				Image: pointer.StringPtr("image"),
+				Image: pointer.New("image"),
 			},
 		}
 		err = k8sClient.Create(context.Background(), ds)

--- a/controllers/operator.marin3r/discoveryservicecertificate_controller_suite_test.go
+++ b/controllers/operator.marin3r/discoveryservicecertificate_controller_suite_test.go
@@ -6,13 +6,13 @@ import (
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	"github.com/3scale-ops/marin3r/pkg/util/pki"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -129,7 +129,7 @@ var _ = Describe("DiscoveryServiceCertificate controller", func() {
 				},
 				Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
 					CommonName: "test",
-					IsCA:       pointer.BoolPtr(true),
+					IsCA:       pointer.New(true),
 					ValidFor:   3600,
 					Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
 						SelfSigned: &operatorv1alpha1.SelfSignedConfig{},

--- a/controllers/operator.marin3r/envoydeployment_controller_suite_test.go
+++ b/controllers/operator.marin3r/envoydeployment_controller_suite_test.go
@@ -6,7 +6,9 @@ import (
 
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/envoy"
 	"github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -16,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -49,7 +50,7 @@ var _ = Describe("EnvoyDeployment controller", func() {
 				Namespace: namespace,
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceSpec{
-				Image: pointer.String("image"),
+				Image: pointer.New("image"),
 			},
 		}
 		err = k8sClient.Create(context.Background(), ds)
@@ -62,7 +63,7 @@ var _ = Describe("EnvoyDeployment controller", func() {
 		ec := &marin3rv1alpha1.EnvoyConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "config", Namespace: namespace},
 			Spec: marin3rv1alpha1.EnvoyConfigSpec{
-				EnvoyAPI:       pointer.String("v3"),
+				EnvoyAPI:       pointer.New(envoy.APIv3),
 				NodeID:         "test-node",
 				EnvoyResources: &marin3rv1alpha1.EnvoyResources{},
 			},
@@ -136,7 +137,7 @@ var _ = Describe("EnvoyDeployment controller", func() {
 									Name: corev1.ResourceCPU,
 									Target: autoscalingv2.MetricTarget{
 										Type:               autoscalingv2.UtilizationMetricType,
-										AverageUtilization: pointer.Int32(50),
+										AverageUtilization: pointer.New(int32(50)),
 									},
 								},
 							},

--- a/pkg/envoy/container/generator.go
+++ b/pkg/envoy/container/generator.go
@@ -6,10 +6,10 @@ import (
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	"github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
 	"github.com/3scale-ops/marin3r/pkg/envoy/container/shutdownmanager"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 type ContainerConfig struct {
@@ -250,7 +250,7 @@ func (cc *ContainerConfig) Volumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  cc.ClientCertSecret,
-					DefaultMode: pointer.Int32(420),
+					DefaultMode: pointer.New(int32(420)),
 				},
 			},
 		},

--- a/pkg/envoy/container/generator_test.go
+++ b/pkg/envoy/container/generator_test.go
@@ -7,11 +7,11 @@ import (
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	"github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
 	"github.com/3scale-ops/marin3r/pkg/envoy/container/shutdownmanager"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"github.com/go-test/deep"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 func TestContainerConfig_Containers(t *testing.T) {
@@ -346,7 +346,7 @@ func TestContainerConfig_Volumes(t *testing.T) {
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  "client-secret",
-							DefaultMode: pointer.Int32(420),
+							DefaultMode: pointer.New(int32(420)),
 						},
 					},
 				},

--- a/pkg/reconcilers/marin3r/envoyconfig/initialize.go
+++ b/pkg/reconcilers/marin3r/envoyconfig/initialize.go
@@ -2,7 +2,7 @@ package reconcilers
 
 import (
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
-	"k8s.io/utils/pointer"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -13,7 +13,7 @@ func IsInitialized(ec *marin3rv1alpha1.EnvoyConfig) bool {
 	ok := true
 
 	if ec.Spec.EnvoyAPI == nil {
-		ec.Spec.EnvoyAPI = pointer.String(string(ec.GetEnvoyAPIVersion()))
+		ec.Spec.EnvoyAPI = pointer.New(ec.GetEnvoyAPIVersion())
 		ok = false
 	}
 

--- a/pkg/reconcilers/marin3r/envoyconfig/initialize_test.go
+++ b/pkg/reconcilers/marin3r/envoyconfig/initialize_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/envoy"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestIsInitialized(t *testing.T) {
@@ -26,7 +27,7 @@ func TestIsInitialized(t *testing.T) {
 			func() *marin3rv1alpha1.EnvoyConfig {
 				return &marin3rv1alpha1.EnvoyConfig{
 					Spec: marin3rv1alpha1.EnvoyConfigSpec{
-						EnvoyAPI: pointer.String("v3"),
+						EnvoyAPI: pointer.New(envoy.APIv3),
 					},
 				}
 			},
@@ -40,7 +41,7 @@ func TestIsInitialized(t *testing.T) {
 						Finalizers: []string{marin3rv1alpha1.EnvoyConfigRevisionFinalizer},
 					},
 					Spec: marin3rv1alpha1.EnvoyConfigSpec{
-						EnvoyAPI: pointer.String("v3"),
+						EnvoyAPI: pointer.New(envoy.APIv3),
 					},
 				}
 			},

--- a/pkg/reconcilers/marin3r/envoyconfig/reconcile_revisions.go
+++ b/pkg/reconcilers/marin3r/envoyconfig/reconcile_revisions.go
@@ -9,11 +9,11 @@ import (
 	"github.com/3scale-ops/marin3r/pkg/envoy"
 	"github.com/3scale-ops/marin3r/pkg/reconcilers/marin3r/envoyconfig/filters"
 	"github.com/3scale-ops/marin3r/pkg/reconcilers/marin3r/envoyconfig/revisions"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -68,7 +68,7 @@ func (r *RevisionReconciler) NodeID() string {
 func (r *RevisionReconciler) DesiredVersion() string {
 	if r.desiredVersion == nil {
 		// Store the version to avoid further computation of the same value
-		r.desiredVersion = pointer.String(r.Instance().GetEnvoyResourcesVersion())
+		r.desiredVersion = pointer.New(r.Instance().GetEnvoyResourcesVersion())
 	}
 	return *r.desiredVersion
 }
@@ -269,7 +269,7 @@ func (r *RevisionReconciler) newRevisionForCurrentResources() *marin3rv1alpha1.E
 		},
 		Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
 			NodeID:    r.NodeID(),
-			EnvoyAPI:  pointer.String(r.EnvoyAPI().String()),
+			EnvoyAPI:  pointer.New(r.EnvoyAPI()),
 			Version:   r.DesiredVersion(),
 			Resources: r.Instance().Spec.Resources,
 		},

--- a/pkg/reconcilers/marin3r/envoyconfig/status_test.go
+++ b/pkg/reconcilers/marin3r/envoyconfig/status_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestIsStatusReconciled(t *testing.T) {
@@ -27,9 +27,9 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				ec: &marin3rv1alpha1.EnvoyConfig{
 					Status: marin3rv1alpha1.EnvoyConfigStatus{
-						DesiredVersion:   pointer.String("6758fd786c"),
-						PublishedVersion: pointer.String("6758fd786c"),
-						CacheState:       pointer.String(marin3rv1alpha1.InSyncState),
+						DesiredVersion:   pointer.New("6758fd786c"),
+						PublishedVersion: pointer.New("6758fd786c"),
+						CacheState:       pointer.New(marin3rv1alpha1.InSyncState),
 						ConfigRevisions: []marin3rv1alpha1.ConfigRevisionRef{
 							{Version: "1", Ref: corev1.ObjectReference{Name: "ecr1", Namespace: "test"}},
 							{Version: "2", Ref: corev1.ObjectReference{Name: "ecr2", Namespace: "test"}},
@@ -62,9 +62,9 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				ec: &marin3rv1alpha1.EnvoyConfig{
 					Status: marin3rv1alpha1.EnvoyConfigStatus{
-						DesiredVersion:   pointer.String("6758fd786c"),
-						PublishedVersion: pointer.String("6758fd786c"),
-						CacheState:       pointer.String(marin3rv1alpha1.InSyncState),
+						DesiredVersion:   pointer.New("6758fd786c"),
+						PublishedVersion: pointer.New("6758fd786c"),
+						CacheState:       pointer.New(marin3rv1alpha1.InSyncState),
 						ConfigRevisions:  []marin3rv1alpha1.ConfigRevisionRef{},
 						Conditions: []metav1.Condition{
 							{Type: marin3rv1alpha1.CacheOutOfSyncCondition, Status: metav1.ConditionFalse, Message: "a"},
@@ -83,9 +83,9 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				ec: &marin3rv1alpha1.EnvoyConfig{
 					Status: marin3rv1alpha1.EnvoyConfigStatus{
-						DesiredVersion:   pointer.String("6758fd786c"),
-						PublishedVersion: pointer.String("6758fd786c"),
-						CacheState:       pointer.String(marin3rv1alpha1.InSyncState),
+						DesiredVersion:   pointer.New("6758fd786c"),
+						PublishedVersion: pointer.New("6758fd786c"),
+						CacheState:       pointer.New(marin3rv1alpha1.InSyncState),
 						ConfigRevisions:  []marin3rv1alpha1.ConfigRevisionRef{},
 						Conditions: []metav1.Condition{
 							{Type: marin3rv1alpha1.CacheOutOfSyncCondition, Status: metav1.ConditionTrue, Message: "a"},
@@ -104,9 +104,9 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				ec: &marin3rv1alpha1.EnvoyConfig{
 					Status: marin3rv1alpha1.EnvoyConfigStatus{
-						DesiredVersion:   pointer.String("6758fd786c"),
-						PublishedVersion: pointer.String("6758fd786c"),
-						CacheState:       pointer.String(marin3rv1alpha1.RollbackFailedState),
+						DesiredVersion:   pointer.New("6758fd786c"),
+						PublishedVersion: pointer.New("6758fd786c"),
+						CacheState:       pointer.New(marin3rv1alpha1.RollbackFailedState),
 						ConfigRevisions:  []marin3rv1alpha1.ConfigRevisionRef{},
 						Conditions: []metav1.Condition{
 							{Type: marin3rv1alpha1.CacheOutOfSyncCondition, Status: metav1.ConditionFalse, Message: "a"},
@@ -125,9 +125,9 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				ec: &marin3rv1alpha1.EnvoyConfig{
 					Status: marin3rv1alpha1.EnvoyConfigStatus{
-						DesiredVersion:   pointer.String("xxxx"),
-						PublishedVersion: pointer.String("6758fd786c"),
-						CacheState:       pointer.String(marin3rv1alpha1.InSyncState),
+						DesiredVersion:   pointer.New("xxxx"),
+						PublishedVersion: pointer.New("6758fd786c"),
+						CacheState:       pointer.New(marin3rv1alpha1.InSyncState),
 						ConfigRevisions:  []marin3rv1alpha1.ConfigRevisionRef{},
 						Conditions: []metav1.Condition{
 							{Type: marin3rv1alpha1.CacheOutOfSyncCondition, Status: metav1.ConditionFalse, Message: "a"},
@@ -146,9 +146,9 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				ec: &marin3rv1alpha1.EnvoyConfig{
 					Status: marin3rv1alpha1.EnvoyConfigStatus{
-						DesiredVersion:   pointer.String("6758fd786c"),
-						PublishedVersion: pointer.String("xxxx"),
-						CacheState:       pointer.String(marin3rv1alpha1.InSyncState),
+						DesiredVersion:   pointer.New("6758fd786c"),
+						PublishedVersion: pointer.New("xxxx"),
+						CacheState:       pointer.New(marin3rv1alpha1.InSyncState),
 						ConfigRevisions:  []marin3rv1alpha1.ConfigRevisionRef{},
 						Conditions: []metav1.Condition{
 							{Type: marin3rv1alpha1.CacheOutOfSyncCondition, Status: metav1.ConditionFalse, Message: "a"},
@@ -167,9 +167,9 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				ec: &marin3rv1alpha1.EnvoyConfig{
 					Status: marin3rv1alpha1.EnvoyConfigStatus{
-						DesiredVersion:   pointer.String("6758fd786c"),
-						PublishedVersion: pointer.String("xxxx"),
-						CacheState:       pointer.String(marin3rv1alpha1.InSyncState),
+						DesiredVersion:   pointer.New("6758fd786c"),
+						PublishedVersion: pointer.New("xxxx"),
+						CacheState:       pointer.New(marin3rv1alpha1.InSyncState),
 						ConfigRevisions:  []marin3rv1alpha1.ConfigRevisionRef{},
 						Conditions: []metav1.Condition{
 							{Type: marin3rv1alpha1.CacheOutOfSyncCondition, Status: metav1.ConditionFalse, Message: "a"},
@@ -200,9 +200,9 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				ec: &marin3rv1alpha1.EnvoyConfig{
 					Status: marin3rv1alpha1.EnvoyConfigStatus{
-						DesiredVersion:   pointer.String("6758fd786c"),
-						PublishedVersion: pointer.String("6758fd786c"),
-						CacheState:       pointer.String(marin3rv1alpha1.InSyncState),
+						DesiredVersion:   pointer.New("6758fd786c"),
+						PublishedVersion: pointer.New("6758fd786c"),
+						CacheState:       pointer.New(marin3rv1alpha1.InSyncState),
 						ConfigRevisions: []marin3rv1alpha1.ConfigRevisionRef{
 							{Version: "1", Ref: corev1.ObjectReference{Name: "ecr1", Namespace: "test"}},
 							{Version: "2", Ref: corev1.ObjectReference{Name: "ecr2", Namespace: "test"}},

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/cache.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/cache.go
@@ -85,7 +85,7 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources [
 	for idx, resourceDefinition := range resources {
 		switch resourceDefinition.Type {
 
-		case string(envoy.Endpoint):
+		case envoy.Endpoint:
 
 			if resourceDefinition.GenerateFromEndpointSlices != nil {
 				// Endpoint discovery enabled
@@ -112,7 +112,7 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources [
 				endpoints = append(endpoints, res)
 			}
 
-		case string(envoy.Cluster):
+		case envoy.Cluster:
 			res := r.generator.New(envoy.Cluster)
 			if err := r.decoder.Unmarshal(string(resourceDefinition.Value.Raw), res); err != nil {
 				return nil,
@@ -123,7 +123,7 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources [
 			}
 			clusters = append(clusters, res)
 
-		case string(envoy.Route):
+		case envoy.Route:
 			res := r.generator.New(envoy.Route)
 			if err := r.decoder.Unmarshal(string(resourceDefinition.Value.Raw), res); err != nil {
 				return nil,
@@ -134,7 +134,7 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources [
 			}
 			routes = append(routes, res)
 
-		case string(envoy.ScopedRoute):
+		case envoy.ScopedRoute:
 			res := r.generator.New(envoy.ScopedRoute)
 			if err := r.decoder.Unmarshal(string(resourceDefinition.Value.Raw), res); err != nil {
 				return nil,
@@ -145,7 +145,7 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources [
 			}
 			scopedRoutes = append(scopedRoutes, res)
 
-		case string(envoy.Listener):
+		case envoy.Listener:
 			res := r.generator.New(envoy.Listener)
 			if err := r.decoder.Unmarshal(string(resourceDefinition.Value.Raw), res); err != nil {
 				return nil,
@@ -156,7 +156,7 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources [
 			}
 			listeners = append(listeners, res)
 
-		case string(envoy.Secret):
+		case envoy.Secret:
 			s := &corev1.Secret{}
 			// The webhook will ensure this pointer is set
 			name := *resourceDefinition.GenerateFromTlsSecret
@@ -178,7 +178,7 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources [
 
 			}
 
-		case string(envoy.Runtime):
+		case envoy.Runtime:
 			res := r.generator.New(envoy.Runtime)
 			if err := r.decoder.Unmarshal(string(resourceDefinition.Value.Raw), res); err != nil {
 				return nil,
@@ -189,7 +189,7 @@ func (r *CacheReconciler) GenerateSnapshot(req types.NamespacedName, resources [
 			}
 			runtimes = append(runtimes, res)
 
-		case string(envoy.ExtensionConfig):
+		case envoy.ExtensionConfig:
 			res := r.generator.New(envoy.ExtensionConfig)
 			if err := r.decoder.Unmarshal(string(resourceDefinition.Value.Raw), res); err != nil {
 				return nil,

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/cache_test.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/cache_test.go
@@ -13,6 +13,7 @@ import (
 	envoy_resources_v3 "github.com/3scale-ops/marin3r/pkg/envoy/resources/v3"
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
 	k8sutil "github.com/3scale-ops/marin3r/pkg/util/k8s"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	testutil "github.com/3scale-ops/marin3r/pkg/util/test"
 	"github.com/davecgh/go-spew/spew"
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -26,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -113,7 +113,7 @@ func TestCacheReconciler_Reconcile(t *testing.T) {
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
 					{
-						Type:  string(envoy.Endpoint),
+						Type:  envoy.Endpoint,
 						Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}"),
 					},
 				},
@@ -192,12 +192,12 @@ func TestCacheReconciler_GenerateSnapshot(t *testing.T) {
 			args: args{
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
-					{Type: string(envoy.Cluster), Value: k8sutil.StringtoRawExtension("{\"name\": \"cluster\"}")},
-					{Type: string(envoy.Route), Value: k8sutil.StringtoRawExtension("{\"name\": \"route\"}")},
-					{Type: string(envoy.ScopedRoute), Value: k8sutil.StringtoRawExtension("{\"name\": \"scoped_route\"}")},
-					{Type: string(envoy.Listener), Value: k8sutil.StringtoRawExtension("{\"name\": \"listener\"}")},
-					{Type: string(envoy.Runtime), Value: k8sutil.StringtoRawExtension("{\"name\": \"runtime\"}")},
+					{Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension("{\"cluster_name\": \"endpoint\"}")},
+					{Type: envoy.Cluster, Value: k8sutil.StringtoRawExtension("{\"name\": \"cluster\"}")},
+					{Type: envoy.Route, Value: k8sutil.StringtoRawExtension("{\"name\": \"route\"}")},
+					{Type: envoy.ScopedRoute, Value: k8sutil.StringtoRawExtension("{\"name\": \"scoped_route\"}")},
+					{Type: envoy.Listener, Value: k8sutil.StringtoRawExtension("{\"name\": \"listener\"}")},
+					{Type: envoy.Runtime, Value: k8sutil.StringtoRawExtension("{\"name\": \"runtime\"}")},
 				},
 			},
 			want: xdss_v3.NewSnapshot().
@@ -234,7 +234,7 @@ func TestCacheReconciler_GenerateSnapshot(t *testing.T) {
 			args: args{
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension("giberish")},
+					{Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension("giberish")},
 				},
 			},
 			wantErr: true,
@@ -253,7 +253,7 @@ func TestCacheReconciler_GenerateSnapshot(t *testing.T) {
 			args: args{
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Cluster), Value: k8sutil.StringtoRawExtension("giberish")},
+					{Type: envoy.Cluster, Value: k8sutil.StringtoRawExtension("giberish")},
 				},
 			},
 			wantErr: true,
@@ -272,7 +272,7 @@ func TestCacheReconciler_GenerateSnapshot(t *testing.T) {
 			args: args{
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Route), Value: k8sutil.StringtoRawExtension("giberish")},
+					{Type: envoy.Route, Value: k8sutil.StringtoRawExtension("giberish")},
 				},
 			},
 			wantErr: true,
@@ -291,7 +291,7 @@ func TestCacheReconciler_GenerateSnapshot(t *testing.T) {
 			args: args{
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
-					{Type: string(envoy.ScopedRoute), Value: k8sutil.StringtoRawExtension("giberish")},
+					{Type: envoy.ScopedRoute, Value: k8sutil.StringtoRawExtension("giberish")},
 				},
 			},
 			wantErr: true,
@@ -310,7 +310,7 @@ func TestCacheReconciler_GenerateSnapshot(t *testing.T) {
 			args: args{
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Listener), Value: k8sutil.StringtoRawExtension("giberish")},
+					{Type: envoy.Listener, Value: k8sutil.StringtoRawExtension("giberish")},
 				},
 			},
 			wantErr: true,
@@ -329,7 +329,7 @@ func TestCacheReconciler_GenerateSnapshot(t *testing.T) {
 			args: args{
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Runtime), Value: k8sutil.StringtoRawExtension("giberish")},
+					{Type: envoy.Runtime, Value: k8sutil.StringtoRawExtension("giberish")},
 				},
 			},
 			wantErr: true,
@@ -352,7 +352,7 @@ func TestCacheReconciler_GenerateSnapshot(t *testing.T) {
 			args: args{
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Secret), GenerateFromTlsSecret: pointer.String("secret")},
+					{Type: envoy.Secret, GenerateFromTlsSecret: pointer.New("secret")},
 				},
 			},
 			wantErr: false,
@@ -386,7 +386,7 @@ func TestCacheReconciler_GenerateSnapshot(t *testing.T) {
 			args: args{
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Secret), GenerateFromTlsSecret: pointer.String("secret")},
+					{Type: envoy.Secret, GenerateFromTlsSecret: pointer.New("secret")},
 				},
 			},
 			wantErr: true,
@@ -405,7 +405,7 @@ func TestCacheReconciler_GenerateSnapshot(t *testing.T) {
 			args: args{
 				req: types.NamespacedName{Name: "xx", Namespace: "xx"},
 				resources: []marin3rv1alpha1.Resource{
-					{Type: string(envoy.Secret), GenerateFromTlsSecret: pointer.String("secret")},
+					{Type: envoy.Secret, GenerateFromTlsSecret: pointer.New("secret")},
 				},
 			},
 			wantErr: true,

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/discover/endpoints_test.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/discover/endpoints_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/3scale-ops/marin3r/pkg/envoy"
 	envoy_resources "github.com/3scale-ops/marin3r/pkg/envoy/resources"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/go-logr/logr"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -53,15 +53,15 @@ func TestEndpoints(t *testing.T) {
 						Endpoints: []discoveryv1.Endpoint{
 							{
 								Addresses:  []string{"127.0.0.1"},
-								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.New(true)},
 							},
 							{
 								Addresses:  []string{"127.0.0.2"},
-								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.New(true)},
 							},
 						},
 						Ports: []discoveryv1.EndpointPort{
-							{Name: pointer.String("port"), Port: pointer.Int32(1001)},
+							{Name: pointer.New("port"), Port: pointer.New(int32(1001))},
 						},
 					},
 				).Build(),
@@ -134,11 +134,11 @@ func TestEndpoints(t *testing.T) {
 						Endpoints: []discoveryv1.Endpoint{
 							{
 								Addresses:  []string{"127.0.0.1"},
-								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.New(true)},
 							},
 						},
 						Ports: []discoveryv1.EndpointPort{
-							{Name: pointer.String("port"), Port: pointer.Int32(1001)},
+							{Name: pointer.New("port"), Port: pointer.New(int32(1001))},
 						},
 					},
 				).Build(),
@@ -169,11 +169,11 @@ func TestEndpoints(t *testing.T) {
 						Endpoints: []discoveryv1.Endpoint{
 							{
 								Addresses:  []string{"127.0.0.1"},
-								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.New(true)},
 							},
 						},
 						Ports: []discoveryv1.EndpointPort{
-							{Name: pointer.String("port"), Port: pointer.Int32(1001)},
+							{Name: pointer.New("port"), Port: pointer.New(int32(1001))},
 						},
 					},
 				).Build(),
@@ -224,16 +224,16 @@ func Test_endpointSlices_to_UpstreamHosts(t *testing.T) {
 							Endpoints: []discoveryv1.Endpoint{
 								{
 									Addresses:  []string{"127.0.0.1"},
-									Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+									Conditions: discoveryv1.EndpointConditions{Ready: pointer.New(true)},
 								},
 								{
 									Addresses:  []string{"127.0.0.2"},
-									Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+									Conditions: discoveryv1.EndpointConditions{Ready: pointer.New(true)},
 								},
 							},
 							Ports: []discoveryv1.EndpointPort{
-								{Name: pointer.String("port1"), Port: pointer.Int32(1001)},
-								{Name: pointer.String("port2"), Port: pointer.Int32(1002)},
+								{Name: pointer.New("port1"), Port: pointer.New(int32(1001))},
+								{Name: pointer.New("port2"), Port: pointer.New(int32(1002))},
 							},
 						},
 						{
@@ -241,16 +241,16 @@ func Test_endpointSlices_to_UpstreamHosts(t *testing.T) {
 							Endpoints: []discoveryv1.Endpoint{
 								{
 									Addresses:  []string{"127.0.0.3"},
-									Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+									Conditions: discoveryv1.EndpointConditions{Ready: pointer.New(true)},
 								},
 								{
 									Addresses:  []string{"127.0.0.4"},
-									Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(false)},
+									Conditions: discoveryv1.EndpointConditions{Ready: pointer.New(false)},
 								},
 							},
 							Ports: []discoveryv1.EndpointPort{
-								{Name: pointer.String("port1"), Port: pointer.Int32(1001)},
-								{Name: pointer.String("port2"), Port: pointer.Int32(1002)},
+								{Name: pointer.New("port1"), Port: pointer.New(int32(1001))},
+								{Name: pointer.New("port2"), Port: pointer.New(int32(1002))},
 							},
 						},
 					},
@@ -300,7 +300,7 @@ func Test_endpointSlices_to_UpstreamHosts(t *testing.T) {
 				esl: &discoveryv1.EndpointSliceList{
 					Items: []discoveryv1.EndpointSlice{{
 						Ports: []discoveryv1.EndpointPort{
-							{Name: pointer.String("port1"), Port: pointer.Int32(1001)},
+							{Name: pointer.New("port1"), Port: pointer.New(int32(1001))},
 						}}},
 				},
 				portName: "other-port",
@@ -318,15 +318,15 @@ func Test_endpointSlices_to_UpstreamHosts(t *testing.T) {
 						Endpoints: []discoveryv1.Endpoint{
 							{
 								Addresses:  []string{"xxxx"},
-								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.New(true)},
 							},
 							{
 								Addresses:  []string{"127.0.0.2"},
-								Conditions: discoveryv1.EndpointConditions{Ready: pointer.Bool(true)},
+								Conditions: discoveryv1.EndpointConditions{Ready: pointer.New(true)},
 							},
 						},
 						Ports: []discoveryv1.EndpointPort{
-							{Name: pointer.String("port1"), Port: pointer.Int32(1001)},
+							{Name: pointer.New("port1"), Port: pointer.New(int32(1001))},
 						},
 					}},
 				},
@@ -368,9 +368,9 @@ func Test_health(t *testing.T) {
 			name: "HEALTHY",
 			args: args{
 				ec: discoveryv1.EndpointConditions{
-					Ready:       pointer.Bool(true),
-					Serving:     pointer.Bool(true),
-					Terminating: pointer.Bool(false),
+					Ready:       pointer.New(true),
+					Serving:     pointer.New(true),
+					Terminating: pointer.New(false),
 				},
 			},
 			want: envoy.HealthStatus_HEALTHY,
@@ -379,8 +379,8 @@ func Test_health(t *testing.T) {
 			name: "HEALTHY",
 			args: args{
 				ec: discoveryv1.EndpointConditions{
-					Ready:   pointer.Bool(true),
-					Serving: pointer.Bool(true),
+					Ready:   pointer.New(true),
+					Serving: pointer.New(true),
 				},
 			},
 			want: envoy.HealthStatus_HEALTHY,
@@ -389,7 +389,7 @@ func Test_health(t *testing.T) {
 			name: "HEALTHY",
 			args: args{
 				ec: discoveryv1.EndpointConditions{
-					Ready: pointer.Bool(true),
+					Ready: pointer.New(true),
 				},
 			},
 			want: envoy.HealthStatus_HEALTHY,
@@ -398,7 +398,7 @@ func Test_health(t *testing.T) {
 			name: "UNHEALTHY",
 			args: args{
 				ec: discoveryv1.EndpointConditions{
-					Ready: pointer.Bool(false),
+					Ready: pointer.New(false),
 				},
 			},
 			want: envoy.HealthStatus_UNHEALTHY,
@@ -407,7 +407,7 @@ func Test_health(t *testing.T) {
 			name: "UNHEALTHY",
 			args: args{
 				ec: discoveryv1.EndpointConditions{
-					Serving: pointer.Bool(false),
+					Serving: pointer.New(false),
 				},
 			},
 			want: envoy.HealthStatus_UNHEALTHY,
@@ -423,7 +423,7 @@ func Test_health(t *testing.T) {
 			name: "DRAINING",
 			args: args{
 				ec: discoveryv1.EndpointConditions{
-					Terminating: pointer.Bool(true),
+					Terminating: pointer.New(true),
 				},
 			},
 			want: envoy.HealthStatus_DRAINING,

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/initialize.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/initialize.go
@@ -2,7 +2,7 @@ package reconcilers
 
 import (
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
-	"k8s.io/utils/pointer"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -13,7 +13,7 @@ func IsInitialized(ecr *marin3rv1alpha1.EnvoyConfigRevision) bool {
 	ok := true
 
 	if ecr.Spec.EnvoyAPI == nil {
-		ecr.Spec.EnvoyAPI = pointer.String(string(ecr.GetEnvoyAPIVersion()))
+		ecr.Spec.EnvoyAPI = pointer.New(ecr.GetEnvoyAPIVersion())
 		ok = false
 	}
 

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/initialize_test.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/initialize_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/envoy"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestIsInitialized(t *testing.T) {
@@ -29,7 +30,7 @@ func TestIsInitialized(t *testing.T) {
 						Finalizers: []string{marin3rv1alpha1.EnvoyConfigRevisionFinalizer},
 					},
 					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
-						EnvoyAPI: pointer.String("v3"),
+						EnvoyAPI: pointer.New(envoy.APIv3),
 					},
 				}
 			},

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/status.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/status.go
@@ -11,9 +11,9 @@ import (
 	envoy "github.com/3scale-ops/marin3r/pkg/envoy"
 	envoy_resources "github.com/3scale-ops/marin3r/pkg/envoy/resources"
 	k8sutil "github.com/3scale-ops/marin3r/pkg/util/k8s"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 // IsStatusReconciled calculates the status of the resource
@@ -57,20 +57,20 @@ func IsStatusReconciled(ecr *marin3rv1alpha1.EnvoyConfigRevision, vt *marin3rv1a
 
 	// Set status.published and status.lastPublishedAt fields
 	if meta.IsStatusConditionTrue(ecr.Status.Conditions, marin3rv1alpha1.RevisionPublishedCondition) && !ecr.Status.IsPublished() {
-		ecr.Status.Published = pointer.Bool(true)
+		ecr.Status.Published = pointer.New(true)
 		ecr.Status.LastPublishedAt = func(t metav1.Time) *metav1.Time { return &t }(metav1.Now())
 		ok = false
 	} else if !meta.IsStatusConditionTrue(ecr.Status.Conditions, marin3rv1alpha1.RevisionPublishedCondition) && ecr.Status.IsPublished() {
-		ecr.Status.Published = pointer.Bool(false)
+		ecr.Status.Published = pointer.New(false)
 		ok = false
 	}
 
 	// Set status.tainted field
 	if meta.IsStatusConditionTrue(ecr.Status.Conditions, marin3rv1alpha1.RevisionTaintedCondition) && !ecr.Status.IsTainted() {
-		ecr.Status.Tainted = pointer.Bool(true)
+		ecr.Status.Tainted = pointer.New(true)
 		ok = false
 	} else if !meta.IsStatusConditionTrue(ecr.Status.Conditions, marin3rv1alpha1.RevisionTaintedCondition) && ecr.Status.IsTainted() {
-		ecr.Status.Tainted = pointer.Bool(false)
+		ecr.Status.Tainted = pointer.New(false)
 		ok = false
 	}
 

--- a/pkg/reconcilers/marin3r/envoyconfigrevision/status_test.go
+++ b/pkg/reconcilers/marin3r/envoyconfigrevision/status_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/stats"
 	xdss_v3 "github.com/3scale-ops/marin3r/pkg/discoveryservice/xdss/v3"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"github.com/davecgh/go-spew/spew"
 	resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/patrickmn/go-cache"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestIsStatusReconciled(t *testing.T) {
@@ -75,7 +75,7 @@ func TestIsStatusReconciled(t *testing.T) {
 							NodeID:  "test",
 						},
 						Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
-							Published: pointer.Bool(true),
+							Published: pointer.New(true),
 							ProvidesVersions: &marin3rv1alpha1.VersionTracker{
 								Endpoints: "a",
 								Clusters:  "b",
@@ -129,7 +129,7 @@ func TestIsStatusReconciled(t *testing.T) {
 							NodeID:  "test",
 						},
 						Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
-							Published:       pointer.Bool(true),
+							Published:       pointer.New(true),
 							LastPublishedAt: func(t metav1.Time) *metav1.Time { return &t }(metav1.Now()),
 							Conditions: []metav1.Condition{
 								{Type: marin3rv1alpha1.RevisionPublishedCondition, Status: metav1.ConditionFalse},
@@ -158,7 +158,7 @@ func TestIsStatusReconciled(t *testing.T) {
 							NodeID:  "test",
 						},
 						Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
-							Published:       pointer.Bool(false),
+							Published:       pointer.New(false),
 							LastPublishedAt: func(t metav1.Time) *metav1.Time { return &t }(metav1.Now()),
 							Conditions: []metav1.Condition{
 								{Type: marin3rv1alpha1.RevisionPublishedCondition, Status: metav1.ConditionFalse},
@@ -184,7 +184,7 @@ func TestIsStatusReconciled(t *testing.T) {
 						Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
 							Version:  "xxxx",
 							NodeID:   "test",
-							EnvoyAPI: pointer.String(envoy.APIv3.String()),
+							EnvoyAPI: pointer.New(envoy.APIv3),
 						},
 						Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
 							ProvidesVersions: &marin3rv1alpha1.VersionTracker{Endpoints: "aaaa"},
@@ -214,11 +214,11 @@ func TestIsStatusReconciled(t *testing.T) {
 						Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
 							Version:  "xxxx",
 							NodeID:   "test",
-							EnvoyAPI: pointer.String(envoy.APIv3.String()),
+							EnvoyAPI: pointer.New(envoy.APIv3),
 						},
 						Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
 							ProvidesVersions: &marin3rv1alpha1.VersionTracker{Endpoints: "aaaa"},
-							Tainted:          pointer.Bool(true),
+							Tainted:          pointer.New(true),
 							Conditions: []metav1.Condition{
 								{
 									Type:    marin3rv1alpha1.RevisionTaintedCondition,
@@ -281,7 +281,7 @@ func TestIsStatusReconciled(t *testing.T) {
 							NodeID:  "test",
 						},
 						Status: marin3rv1alpha1.EnvoyConfigRevisionStatus{
-							Tainted: pointer.Bool(true),
+							Tainted: pointer.New(true),
 							Conditions: []metav1.Condition{
 								{Type: marin3rv1alpha1.RevisionTaintedCondition, Status: metav1.ConditionTrue},
 							},
@@ -396,7 +396,7 @@ func Test_calculateRevisionTaintedCondition(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "ecr", Namespace: "test"},
 					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
 						NodeID:   "node",
-						EnvoyAPI: pointer.String(envoy.APIv3.String()),
+						EnvoyAPI: pointer.New(envoy.APIv3),
 					},
 				},
 				vt: &marin3rv1alpha1.VersionTracker{
@@ -428,7 +428,7 @@ func Test_calculateRevisionTaintedCondition(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "ecr", Namespace: "test"},
 					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
 						NodeID:   "node",
-						EnvoyAPI: pointer.String(envoy.APIv3.String()),
+						EnvoyAPI: pointer.New(envoy.APIv3),
 					},
 				},
 				vt: &marin3rv1alpha1.VersionTracker{
@@ -458,7 +458,7 @@ func Test_calculateRevisionTaintedCondition(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "ecr", Namespace: "test"},
 					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
 						NodeID:   "node",
-						EnvoyAPI: pointer.String(envoy.APIv3.String()),
+						EnvoyAPI: pointer.New(envoy.APIv3),
 					},
 				},
 				vt: &marin3rv1alpha1.VersionTracker{
@@ -487,7 +487,7 @@ func Test_calculateRevisionTaintedCondition(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "ecr", Namespace: "test"},
 					Spec: marin3rv1alpha1.EnvoyConfigRevisionSpec{
 						NodeID:   "node",
-						EnvoyAPI: pointer.String(envoy.APIv3.String()),
+						EnvoyAPI: pointer.New(envoy.APIv3),
 					},
 				}, vt: &marin3rv1alpha1.VersionTracker{},
 				dStats:     stats.NewWithItems(map[string]cache.Item{}, time.Now()),

--- a/pkg/reconcilers/operator/discoveryservice/generators/certificate_root.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/certificate_root.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func (cfg *GeneratorOptions) RootCertificationAuthority() func() *operatorv1alpha1.DiscoveryServiceCertificate {
@@ -25,7 +25,7 @@ func (cfg *GeneratorOptions) RootCertificationAuthority() func() *operatorv1alph
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
 				CommonName: fmt.Sprintf("%s-%s", cfg.RootCertificateCommonNamePrefix, cfg.InstanceName),
-				IsCA:       pointer.BoolPtr(true),
+				IsCA:       pointer.New(true),
 				ValidFor:   int64(cfg.RootCertificateDuration.Seconds()),
 				Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
 					SelfSigned: &operatorv1alpha1.SelfSignedConfig{},

--- a/pkg/reconcilers/operator/discoveryservice/generators/certificate_root_test.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/certificate_root_test.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestGeneratorOptions_RootCertificationAuthority(t *testing.T) {
@@ -57,7 +57,7 @@ func TestGeneratorOptions_RootCertificationAuthority(t *testing.T) {
 				},
 				Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
 					CommonName: "test-test",
-					IsCA:       pointer.BoolPtr(true),
+					IsCA:       pointer.New(true),
 					ValidFor:   int64(10),
 					Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
 						SelfSigned: &operatorv1alpha1.SelfSignedConfig{},

--- a/pkg/reconcilers/operator/discoveryservice/generators/certificate_server.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/certificate_server.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
-	// cert-manager
 )
 
 func (cfg *GeneratorOptions) ServerCertificate() func() *operatorv1alpha1.DiscoveryServiceCertificate {
@@ -26,7 +25,7 @@ func (cfg *GeneratorOptions) ServerCertificate() func() *operatorv1alpha1.Discov
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
 				CommonName:          fmt.Sprintf("%s-%s", cfg.ServerCertificateCommonNamePrefix, cfg.InstanceName),
-				IsServerCertificate: pointer.BoolPtr(true),
+				IsServerCertificate: pointer.New(true),
 				ValidFor:            int64(cfg.ServerCertificateDuration.Seconds()),
 				Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
 					CASigned: &operatorv1alpha1.CASignedConfig{

--- a/pkg/reconcilers/operator/discoveryservice/generators/certificate_server_test.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/certificate_server_test.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestGeneratorOptions_ServerCertificate(t *testing.T) {
@@ -57,7 +57,7 @@ func TestGeneratorOptions_ServerCertificate(t *testing.T) {
 				},
 				Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
 					CommonName:          "test-test",
-					IsServerCertificate: pointer.BoolPtr(true),
+					IsServerCertificate: pointer.New(true),
 					ValidFor:            int64(10),
 					Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
 						CASigned: &operatorv1alpha1.CASignedConfig{

--- a/pkg/reconcilers/operator/discoveryservice/generators/deployment.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/deployment.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 func (cfg *GeneratorOptions) Deployment(hash string) func() *appsv1.Deployment {
@@ -26,7 +26,7 @@ func (cfg *GeneratorOptions) Deployment(hash string) func() *appsv1.Deployment {
 				Labels:    cfg.labels(),
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: pointer.Int32(1),
+				Replicas: pointer.New(int32(1)),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: cfg.labels(),
 				},
@@ -46,7 +46,7 @@ func (cfg *GeneratorOptions) Deployment(hash string) func() *appsv1.Deployment {
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName:  cfg.ServerCertName(),
-										DefaultMode: pointer.Int32Ptr(420),
+										DefaultMode: pointer.New(int32(420)),
 									},
 								},
 							},
@@ -55,7 +55,7 @@ func (cfg *GeneratorOptions) Deployment(hash string) func() *appsv1.Deployment {
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName:  cfg.RootCertName(),
-										DefaultMode: pointer.Int32Ptr(420),
+										DefaultMode: pointer.New(int32(420)),
 									},
 								},
 							},
@@ -117,7 +117,7 @@ func (cfg *GeneratorOptions) Deployment(hash string) func() *appsv1.Deployment {
 							},
 						},
 						RestartPolicy:                 corev1.RestartPolicyAlways,
-						TerminationGracePeriodSeconds: pointer.Int64Ptr(corev1.DefaultTerminationGracePeriodSeconds),
+						TerminationGracePeriodSeconds: pointer.New(int64(corev1.DefaultTerminationGracePeriodSeconds)),
 						DNSPolicy:                     corev1.DNSClusterFirst,
 						ServiceAccountName:            cfg.ResourceName(),
 						DeprecatedServiceAccount:      cfg.ResourceName(),
@@ -138,8 +138,8 @@ func (cfg *GeneratorOptions) Deployment(hash string) func() *appsv1.Deployment {
 						},
 					},
 				},
-				RevisionHistoryLimit:    pointer.Int32(10),
-				ProgressDeadlineSeconds: pointer.Int32(600),
+				RevisionHistoryLimit:    pointer.New(int32(10)),
+				ProgressDeadlineSeconds: pointer.New(int32(600)),
 			},
 		}
 

--- a/pkg/reconcilers/operator/discoveryservice/generators/deployment_test.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/deployment_test.go
@@ -5,12 +5,12 @@ import (
 	"time"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 func TestGeneratorOptions_Deployment(t *testing.T) {
@@ -40,7 +40,7 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 				DeploymentImage:                   "test:latest",
 				DeploymentResources:               corev1.ResourceRequirements{},
 				Debug:                             true,
-				PodPriorityClass:                  pointer.String("highest"),
+				PodPriorityClass:                  pointer.New("highest"),
 			},
 			args{hash: "hash"},
 			&appsv1.Deployment{
@@ -59,7 +59,7 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: pointer.New(int32(1)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"app.kubernetes.io/name":       "marin3r",
@@ -85,7 +85,7 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  "server-cert-test",
-											DefaultMode: pointer.Int32Ptr(420),
+											DefaultMode: pointer.New(int32(420)),
 										},
 									},
 								},
@@ -94,7 +94,7 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  "ca-cert-test",
-											DefaultMode: pointer.Int32Ptr(420),
+											DefaultMode: pointer.New(int32(420)),
 										},
 									},
 								},
@@ -151,7 +151,7 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 								},
 							},
 							RestartPolicy:                 corev1.RestartPolicyAlways,
-							TerminationGracePeriodSeconds: pointer.Int64Ptr(corev1.DefaultTerminationGracePeriodSeconds),
+							TerminationGracePeriodSeconds: pointer.New(int64(corev1.DefaultTerminationGracePeriodSeconds)),
 							DNSPolicy:                     corev1.DNSClusterFirst,
 							ServiceAccountName:            "marin3r-test",
 							DeprecatedServiceAccount:      "marin3r-test",
@@ -173,8 +173,8 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 							},
 						},
 					},
-					RevisionHistoryLimit:    pointer.Int32Ptr(10),
-					ProgressDeadlineSeconds: pointer.Int32Ptr(600),
+					RevisionHistoryLimit:    pointer.New(int32(10)),
+					ProgressDeadlineSeconds: pointer.New(int32(600)),
 				},
 			},
 		},

--- a/pkg/reconcilers/operator/discoveryservicecertificate/initialize.go
+++ b/pkg/reconcilers/operator/discoveryservicecertificate/initialize.go
@@ -2,7 +2,7 @@ package reconcilers
 
 import (
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
-	"k8s.io/utils/pointer"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 )
 
 // IsInitialized checks whether the EnvoyConfigRevision object is initialized
@@ -12,11 +12,11 @@ func IsInitialized(dsc *operatorv1alpha1.DiscoveryServiceCertificate) bool {
 	ok := true
 
 	if dsc.Spec.IsServerCertificate == nil {
-		dsc.Spec.IsServerCertificate = pointer.BoolPtr(dsc.IsServerCertificate())
+		dsc.Spec.IsServerCertificate = pointer.New(dsc.IsServerCertificate())
 		ok = false
 	}
 	if dsc.Spec.IsCA == nil {
-		dsc.Spec.IsCA = pointer.BoolPtr(dsc.IsCA())
+		dsc.Spec.IsCA = pointer.New(dsc.IsCA())
 		ok = false
 	}
 	if dsc.Spec.Hosts == nil {

--- a/pkg/reconcilers/operator/discoveryservicecertificate/initialize_test.go
+++ b/pkg/reconcilers/operator/discoveryservicecertificate/initialize_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
-	"k8s.io/utils/pointer"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 )
 
 func TestIsInitialized(t *testing.T) {
@@ -21,8 +21,8 @@ func TestIsInitialized(t *testing.T) {
 			args: args{
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
-						IsServerCertificate:      pointer.BoolPtr(false),
-						IsCA:                     pointer.BoolPtr(false),
+						IsServerCertificate:      pointer.New(false),
+						IsCA:                     pointer.New(false),
 						Hosts:                    []string{"host"},
 						CertificateRenewalConfig: &operatorv1alpha1.CertificateRenewalConfig{Enabled: true},
 					},
@@ -35,7 +35,7 @@ func TestIsInitialized(t *testing.T) {
 			args: args{
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
-						IsCA:                     pointer.BoolPtr(false),
+						IsCA:                     pointer.New(false),
 						Hosts:                    []string{"host"},
 						CertificateRenewalConfig: &operatorv1alpha1.CertificateRenewalConfig{Enabled: true},
 					},
@@ -48,7 +48,7 @@ func TestIsInitialized(t *testing.T) {
 			args: args{
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
-						IsServerCertificate:      pointer.BoolPtr(false),
+						IsServerCertificate:      pointer.New(false),
 						Hosts:                    []string{"host"},
 						CertificateRenewalConfig: &operatorv1alpha1.CertificateRenewalConfig{Enabled: true},
 					},
@@ -62,8 +62,8 @@ func TestIsInitialized(t *testing.T) {
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
 						CommonName:               "test",
-						IsServerCertificate:      pointer.BoolPtr(false),
-						IsCA:                     pointer.BoolPtr(false),
+						IsServerCertificate:      pointer.New(false),
+						IsCA:                     pointer.New(false),
 						CertificateRenewalConfig: &operatorv1alpha1.CertificateRenewalConfig{Enabled: true},
 					},
 				},
@@ -75,8 +75,8 @@ func TestIsInitialized(t *testing.T) {
 			args: args{
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
-						IsServerCertificate: pointer.BoolPtr(false),
-						IsCA:                pointer.BoolPtr(false),
+						IsServerCertificate: pointer.New(false),
+						IsCA:                pointer.New(false),
 						Hosts:               []string{"host"},
 					},
 				},

--- a/pkg/reconcilers/operator/discoveryservicecertificate/status.go
+++ b/pkg/reconcilers/operator/discoveryservicecertificate/status.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 // IsStatusReconciled calculates the status of the resource
@@ -16,12 +16,12 @@ func IsStatusReconciled(dsc *operatorv1alpha1.DiscoveryServiceCertificate, certi
 	ok := true
 
 	if dsc.Status.GetCertificateHash() != certificateHash {
-		dsc.Status.CertificateHash = pointer.StringPtr(certificateHash)
+		dsc.Status.CertificateHash = pointer.New(certificateHash)
 		ok = false
 	}
 
 	if dsc.Status.IsReady() != ready {
-		dsc.Status.Ready = pointer.BoolPtr(ready)
+		dsc.Status.Ready = pointer.New(ready)
 		ok = false
 	}
 

--- a/pkg/reconcilers/operator/discoveryservicecertificate/status_test.go
+++ b/pkg/reconcilers/operator/discoveryservicecertificate/status_test.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 var t1, t2 time.Time
@@ -35,8 +35,8 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Status: operatorv1alpha1.DiscoveryServiceCertificateStatus{
-						Ready:           pointer.BoolPtr(true),
-						CertificateHash: pointer.StringPtr("xxxx"),
+						Ready:           pointer.New(true),
+						CertificateHash: pointer.New("xxxx"),
 						NotBefore:       &metav1.Time{Time: t1},
 						NotAfter:        &metav1.Time{Time: t2},
 						Conditions:      []metav1.Condition{},
@@ -54,8 +54,8 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Status: operatorv1alpha1.DiscoveryServiceCertificateStatus{
-						Ready:           pointer.BoolPtr(false),
-						CertificateHash: pointer.StringPtr("xxxx"),
+						Ready:           pointer.New(false),
+						CertificateHash: pointer.New("xxxx"),
 						NotBefore:       &metav1.Time{Time: t1},
 						NotAfter:        &metav1.Time{Time: t2},
 						Conditions:      []metav1.Condition{},
@@ -73,8 +73,8 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Status: operatorv1alpha1.DiscoveryServiceCertificateStatus{
-						Ready:           pointer.BoolPtr(true),
-						CertificateHash: pointer.StringPtr("xxxx"),
+						Ready:           pointer.New(true),
+						CertificateHash: pointer.New("xxxx"),
 						NotBefore:       &metav1.Time{Time: t1},
 						NotAfter:        &metav1.Time{Time: t2},
 						Conditions:      []metav1.Condition{},
@@ -92,8 +92,8 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Status: operatorv1alpha1.DiscoveryServiceCertificateStatus{
-						Ready:           pointer.BoolPtr(true),
-						CertificateHash: pointer.StringPtr("xxxx"),
+						Ready:           pointer.New(true),
+						CertificateHash: pointer.New("xxxx"),
 						NotBefore:       &metav1.Time{},
 						NotAfter:        &metav1.Time{Time: t2},
 						Conditions:      []metav1.Condition{},
@@ -111,8 +111,8 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Status: operatorv1alpha1.DiscoveryServiceCertificateStatus{
-						Ready:           pointer.BoolPtr(true),
-						CertificateHash: pointer.StringPtr("xxxx"),
+						Ready:           pointer.New(true),
+						CertificateHash: pointer.New("xxxx"),
 						NotBefore:       &metav1.Time{Time: t1},
 						NotAfter:        &metav1.Time{},
 						Conditions:      []metav1.Condition{},
@@ -130,8 +130,8 @@ func TestIsStatusReconciled(t *testing.T) {
 			args: args{
 				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
 					Status: operatorv1alpha1.DiscoveryServiceCertificateStatus{
-						Ready:           pointer.BoolPtr(true),
-						CertificateHash: pointer.StringPtr("xxxx"),
+						Ready:           pointer.New(true),
+						CertificateHash: pointer.New("xxxx"),
 						NotBefore:       &metav1.Time{Time: t1},
 						NotAfter:        &metav1.Time{Time: t1},
 					},

--- a/pkg/reconcilers/operator/envoydeployment/generators/deployment.go
+++ b/pkg/reconcilers/operator/envoydeployment/generators/deployment.go
@@ -5,11 +5,11 @@ import (
 
 	envoy_container "github.com/3scale-ops/marin3r/pkg/envoy/container"
 	defaults "github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 func (cfg *GeneratorOptions) Deployment() func() *appsv1.Deployment {
@@ -104,7 +104,7 @@ func (cfg *GeneratorOptions) Deployment() func() *appsv1.Deployment {
 								d := cfg.ShutdownManager.GetDrainTime()
 								return &d
 							}
-							return pointer.Int64(corev1.DefaultTerminationGracePeriodSeconds)
+							return pointer.New(int64(corev1.DefaultTerminationGracePeriodSeconds))
 						}(),
 						SecurityContext: &corev1.PodSecurityContext{},
 						SchedulerName:   corev1.DefaultSchedulerName,
@@ -123,8 +123,8 @@ func (cfg *GeneratorOptions) Deployment() func() *appsv1.Deployment {
 						},
 					},
 				},
-				RevisionHistoryLimit:    pointer.Int32(10),
-				ProgressDeadlineSeconds: pointer.Int32(600),
+				RevisionHistoryLimit:    pointer.New(int32(10)),
+				ProgressDeadlineSeconds: pointer.New(int32(600)),
 			},
 		}
 

--- a/pkg/reconcilers/operator/envoydeployment/generators/deployment_test.go
+++ b/pkg/reconcilers/operator/envoydeployment/generators/deployment_test.go
@@ -7,12 +7,12 @@ import (
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	defaults "github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"github.com/go-test/deep"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 func TestGeneratorOptions_Deployment(t *testing.T) {
@@ -37,10 +37,10 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 				ExposedPorts:              []operatorv1alpha1.ContainerPort{{Name: "port", Port: 8080}},
 				AdminPort:                 9901,
 				AdminAccessLogPath:        "/dev/null",
-				Replicas:                  operatorv1alpha1.ReplicasSpec{Static: pointer.Int32Ptr(1)},
+				Replicas:                  operatorv1alpha1.ReplicasSpec{Static: pointer.New(int32(1))},
 				LivenessProbe:             operatorv1alpha1.ProbeSpec{InitialDelaySeconds: 30, TimeoutSeconds: 1, PeriodSeconds: 10, SuccessThreshold: 1, FailureThreshold: 10},
 				ReadinessProbe:            operatorv1alpha1.ProbeSpec{InitialDelaySeconds: 15, TimeoutSeconds: 1, PeriodSeconds: 5, SuccessThreshold: 1, FailureThreshold: 1},
-				InitManager:               &operatorv1alpha1.InitManager{Image: pointer.StringPtr("init-manager:latest")},
+				InitManager:               &operatorv1alpha1.InitManager{Image: pointer.New("init-manager:latest")},
 			},
 			want: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
@@ -58,7 +58,7 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: pointer.New(int32(1)),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"app.kubernetes.io/name":       "marin3r",
@@ -83,7 +83,7 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  defaults.DeploymentClientCertificate + "-instance",
-											DefaultMode: pointer.Int32(420),
+											DefaultMode: pointer.New(int32(420)),
 										},
 									},
 								},
@@ -221,7 +221,7 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 								},
 							},
 							RestartPolicy:                 corev1.RestartPolicyAlways,
-							TerminationGracePeriodSeconds: pointer.Int64Ptr(corev1.DefaultTerminationGracePeriodSeconds),
+							TerminationGracePeriodSeconds: pointer.New(int64(corev1.DefaultTerminationGracePeriodSeconds)),
 							DNSPolicy:                     corev1.DNSClusterFirst,
 							ServiceAccountName:            "default",
 							DeprecatedServiceAccount:      "default",
@@ -242,8 +242,8 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 							},
 						},
 					},
-					RevisionHistoryLimit:    pointer.Int32Ptr(10),
-					ProgressDeadlineSeconds: pointer.Int32Ptr(600),
+					RevisionHistoryLimit:    pointer.New(int32(10)),
+					ProgressDeadlineSeconds: pointer.New(int32(600)),
 				},
 			},
 		},

--- a/pkg/reconcilers/operator/envoydeployment/generators/hpa_test.go
+++ b/pkg/reconcilers/operator/envoydeployment/generators/hpa_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestGeneratorOptions_HPA(t *testing.T) {
@@ -25,7 +25,7 @@ func TestGeneratorOptions_HPA(t *testing.T) {
 				Namespace:    "default",
 				Replicas: operatorv1alpha1.ReplicasSpec{
 					Dynamic: &operatorv1alpha1.DynamicReplicasSpec{
-						MinReplicas: pointer.Int32Ptr(2),
+						MinReplicas: pointer.New(int32(2)),
 						MaxReplicas: 4,
 						Metrics: []autoscalingv2.MetricSpec{
 							{
@@ -34,7 +34,7 @@ func TestGeneratorOptions_HPA(t *testing.T) {
 									Name: corev1.ResourceCPU,
 									Target: autoscalingv2.MetricTarget{
 										Type:               autoscalingv2.UtilizationMetricType,
-										AverageUtilization: pointer.Int32Ptr(50),
+										AverageUtilization: pointer.New(int32(50)),
 									},
 								},
 							},
@@ -63,7 +63,7 @@ func TestGeneratorOptions_HPA(t *testing.T) {
 						Kind:       "Deployment",
 						Name:       "marin3r-envoydeployment-instance",
 					},
-					MinReplicas: pointer.Int32Ptr(2),
+					MinReplicas: pointer.New(int32(2)),
 					MaxReplicas: 4,
 					Metrics: []autoscalingv2.MetricSpec{
 						{
@@ -72,7 +72,7 @@ func TestGeneratorOptions_HPA(t *testing.T) {
 								Name: corev1.ResourceCPU,
 								Target: autoscalingv2.MetricTarget{
 									Type:               autoscalingv2.UtilizationMetricType,
-									AverageUtilization: pointer.Int32Ptr(50),
+									AverageUtilization: pointer.New(int32(50)),
 								},
 							},
 						},

--- a/pkg/util/pointer/pointer.go
+++ b/pkg/util/pointer/pointer.go
@@ -1,0 +1,5 @@
+package pointer
+
+func New[T any](t T) *T {
+	return &t
+}

--- a/test/e2e/marin3r/discoveryservice_suite_test.go
+++ b/test/e2e/marin3r/discoveryservice_suite_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	testutil "github.com/3scale-ops/marin3r/test/e2e/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -10,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
@@ -46,7 +46,7 @@ var _ = Describe("DiscoveryService intall and lifecycle", func() {
 				Namespace: testNamespace,
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceSpec{
-				Image: pointer.String(image),
+				Image: pointer.New(image),
 			},
 		}
 		err = k8sClient.Create(context.Background(), ds)
@@ -130,7 +130,7 @@ var _ = Describe("DiscoveryService intall and lifecycle", func() {
 		It("reconciles the discovery service deployment", func() {
 
 			patch := client.MergeFrom(ds.DeepCopy())
-			ds.Spec.Debug = pointer.Bool(true)
+			ds.Spec.Debug = pointer.New(true)
 			generation := ds.GetGeneration()
 			err := k8sClient.Patch(context.Background(), ds, patch)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/marin3r/envoydeployment_suite_test.go
+++ b/test/e2e/marin3r/envoydeployment_suite_test.go
@@ -11,6 +11,7 @@ import (
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
 	"github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	testutil "github.com/3scale-ops/marin3r/test/e2e/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -52,7 +52,7 @@ var _ = Describe("EnvoyDeployment", func() {
 				Namespace: testNamespace,
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceSpec{
-				Image: pointer.String(image),
+				Image: pointer.New(image),
 			},
 		}
 		err = k8sClient.Create(context.Background(), ds)
@@ -144,8 +144,8 @@ var _ = Describe("EnvoyDeployment", func() {
 				Spec: operatorv1alpha1.EnvoyDeploymentSpec{
 					DiscoveryServiceRef: ds.GetName(),
 					EnvoyConfigRef:      ec.GetName(),
-					Image:               pointer.String(defaults.ImageRepo + ":" + envoyVersionV3),
-					InitManager:         &operatorv1alpha1.InitManager{Image: pointer.String(image)},
+					Image:               pointer.New(defaults.ImageRepo + ":" + envoyVersionV3),
+					InitManager:         &operatorv1alpha1.InitManager{Image: pointer.New(image)},
 				},
 			}
 

--- a/test/e2e/marin3r/pod_suite_test.go
+++ b/test/e2e/marin3r/pod_suite_test.go
@@ -12,6 +12,7 @@ import (
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	testutil "github.com/3scale-ops/marin3r/test/e2e/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,7 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -53,7 +53,7 @@ var _ = Describe("Envoy pods", func() {
 				Namespace: testNamespace,
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceSpec{
-				Image: pointer.String(image),
+				Image: pointer.New(image),
 			},
 		}
 		err = k8sClient.Create(context.Background(), ds)

--- a/test/e2e/marin3r/sidecar_suite_test.go
+++ b/test/e2e/marin3r/sidecar_suite_test.go
@@ -10,6 +10,7 @@ import (
 	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	"github.com/3scale-ops/marin3r/pkg/envoy"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	testutil "github.com/3scale-ops/marin3r/test/e2e/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -51,7 +51,7 @@ var _ = Describe("Envoy sidecars", func() {
 				Namespace: testNamespace,
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceSpec{
-				Image: pointer.String(image),
+				Image: pointer.New(image),
 			},
 		}
 		err = k8sClient.Create(context.Background(), ds)

--- a/test/e2e/marin3r/suite_test.go
+++ b/test/e2e/marin3r/suite_test.go
@@ -19,20 +19,19 @@ import (
 	"testing"
 	"time"
 
+	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
+	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	"github.com/go-logr/logr"
 	"github.com/goombaio/namegenerator"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-
-	marin3rv1alpha1 "github.com/3scale-ops/marin3r/apis/marin3r/v1alpha1"
-	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
-	"github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
 )
 
 const (
@@ -68,7 +67,7 @@ var _ = BeforeSuite(func() {
 	nameGenerator = namegenerator.NewNameGenerator(seed)
 
 	testEnv = &envtest.Environment{
-		UseExistingCluster: pointer.Bool(true),
+		UseExistingCluster: pointer.New(true),
 	}
 
 	var err error

--- a/test/e2e/util/generators.go
+++ b/test/e2e/util/generators.go
@@ -10,6 +10,7 @@ import (
 	envoy_serializer "github.com/3scale-ops/marin3r/pkg/envoy/serializer"
 	k8sutil "github.com/3scale-ops/marin3r/pkg/util/k8s"
 	"github.com/3scale-ops/marin3r/pkg/util/pki"
+	"github.com/3scale-ops/marin3r/pkg/util/pointer"
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -27,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 )
 
 const (
@@ -198,7 +198,7 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 			Namespace: key.Namespace,
 		},
 		Spec: marin3rv1alpha1.EnvoyConfigSpec{
-			EnvoyAPI:  pointer.String(envoyAPI.String()),
+			EnvoyAPI:  pointer.New(envoyAPI),
 			NodeID:    nodeID,
 			Resources: []marin3rv1alpha1.Resource{},
 		},
@@ -212,12 +212,12 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 			panic(err)
 		}
 		resources = append(resources, marin3rv1alpha1.Resource{
-			Type: string(envoy.Endpoint), Value: k8sutil.StringtoRawExtension(json)})
+			Type: envoy.Endpoint, Value: k8sutil.StringtoRawExtension(json)})
 	}
 
 	for _, e := range eds {
 		resources = append(resources, marin3rv1alpha1.Resource{
-			Type: string(envoy.Endpoint),
+			Type: envoy.Endpoint,
 			GenerateFromEndpointSlices: &marin3rv1alpha1.GenerateFromEndpointSlices{
 				Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{e.LabelKey: e.LabelValue}},
 				ClusterName: e.ClusterName,
@@ -232,7 +232,7 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 			panic(err)
 		}
 		resources = append(resources, marin3rv1alpha1.Resource{
-			Type: string(envoy.Cluster), Value: k8sutil.StringtoRawExtension(json)})
+			Type: envoy.Cluster, Value: k8sutil.StringtoRawExtension(json)})
 	}
 
 	for _, resource := range routes {
@@ -241,7 +241,7 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 			panic(err)
 		}
 		resources = append(resources, marin3rv1alpha1.Resource{
-			Type: string(envoy.Route), Value: k8sutil.StringtoRawExtension(json)})
+			Type: envoy.Route, Value: k8sutil.StringtoRawExtension(json)})
 	}
 
 	for _, resource := range listeners {
@@ -250,13 +250,13 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 			panic(err)
 		}
 		resources = append(resources, marin3rv1alpha1.Resource{
-			Type: string(envoy.Listener), Value: k8sutil.StringtoRawExtension(json)})
+			Type: envoy.Listener, Value: k8sutil.StringtoRawExtension(json)})
 	}
 
 	for _, name := range secrets {
 		resources = append(resources, marin3rv1alpha1.Resource{
-			Type:                  string(envoy.Secret),
-			GenerateFromTlsSecret: pointer.String(name),
+			Type:                  envoy.Secret,
+			GenerateFromTlsSecret: pointer.New(name),
 		})
 	}
 
@@ -266,7 +266,7 @@ func GenerateEnvoyConfig(key types.NamespacedName, nodeID string, envoyAPI envoy
 			panic(err)
 		}
 		resources = append(resources, marin3rv1alpha1.Resource{
-			Type: string(envoy.ExtensionConfig), Value: k8sutil.StringtoRawExtension(json)})
+			Type: envoy.ExtensionConfig, Value: k8sutil.StringtoRawExtension(json)})
 	}
 
 	ec.Spec.Resources = resources


### PR DESCRIPTION
Generics are supported in go since 1.18, so taking advantage of this I added a small utility function that can return a pointer of any type. This makes it easier to apply the proper types to the API definitions and drops usage of the `"k8s.io/utils/pointer"` package.

The function is in `pkg/util/pointer/pointer.go`, all other code changes are to replace the old per type pointer functions by this one.

/kind feature
/priority important-longterm
/assign