### PR TITLE
Discovery service server improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,6 +374,7 @@ run-ds: manifests generate fmt vet go-generate tmp/certs
 		discovery-service \
 		--server-certificate-path tmp/certs/server \
 		--ca-certificate-path tmp/certs/ca \
+		--client-certificate-path tmp/certs/client \
 		--debug
 
 run-envoy: ## runs an envoy process in a container that will try to connect to a local discovery service

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ run-envoy: tmp/certs
 	docker run -ti --rm \
 		--network=host \
 		--add-host marin3r.default.svc:127.0.0.1 \
-		-v $$(pwd)/tmp/certs:/etc/envoy/tls \
+		-v $$(pwd)/tmp/certs/client:/etc/envoy/tls \
 		-v $$(pwd)/examples/local:/config \
 		envoyproxy/envoy:$(ENVOY_VERSION) \
 		envoy -c /config/envoy-client-bootstrap.yaml $(ARGS)

--- a/apis/operator.marin3r/v1alpha1/discoveryservice_types.go
+++ b/apis/operator.marin3r/v1alpha1/discoveryservice_types.go
@@ -41,6 +41,8 @@ const (
 
 	// DefaultMetricsPort is the default port where the discovery service metrics server listens
 	DefaultMetricsPort uint32 = 8383
+	// DefaultProbePort is the default port where the probe server listens
+	DefaultProbePort uint32 = 8384
 	// DefaultXdsServerPort is the default port where the discovery service xds server port listens
 	DefaultXdsServerPort uint32 = 18000
 	// DefaultRootCertificateDuration is the default root CA certificate duration
@@ -97,6 +99,10 @@ type DiscoveryServiceSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
 	MetricsPort *uint32 `json:"metricsPort,omitempty"`
+	// ProbePort is the port where healthz endpoint is served. Defaults to 8384.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +optional
+	ProbePort *uint32 `json:"probePort,omitempty"`
 	// ServiceConfig configures the way the DiscoveryService endpoints are exposed
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
@@ -261,6 +267,14 @@ func (d *DiscoveryService) GetMetricsPort() uint32 {
 		return *d.Spec.MetricsPort
 	}
 	return DefaultMetricsPort
+}
+
+// GetProbePort returns the port the healthz server will listen at
+func (d *DiscoveryService) GetProbePort() uint32 {
+	if d.Spec.ProbePort != nil {
+		return *d.Spec.ProbePort
+	}
+	return DefaultProbePort
 }
 
 // GetServiceConfig returns the Service configuration for the discovery service servers

--- a/config/crd/bases/operator.marin3r.3scale.net_discoveryservices.yaml
+++ b/config/crd/bases/operator.marin3r.3scale.net_discoveryservices.yaml
@@ -87,6 +87,11 @@ spec:
               podPriorityClass:
                 description: PriorityClass to assign the discovery service Pod to
                 type: string
+              probePort:
+                description: ProbePort is the port where healthz endpoint is served.
+                  Defaults to 8384.
+                format: int32
+                type: integer
               resources:
                 description: Resources holds the Resource Requirements to use for
                   the discovery service Deployment. When not set it defaults to no
@@ -96,8 +101,7 @@ spec:
                     description: "Claims lists the names of resources, defined in
                       spec.resourceClaims, that are used by this container. \n This
                       is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable. It can only be set
-                      for containers."
+                      feature gate. \n This field is immutable."
                     items:
                       description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
@@ -133,8 +137,7 @@ spec:
                     description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               serviceConfig:

--- a/config/crd/bases/operator.marin3r.3scale.net_envoydeployments.yaml
+++ b/config/crd/bases/operator.marin3r.3scale.net_envoydeployments.yaml
@@ -1049,18 +1049,18 @@ spec:
                                     which must hold true for a specified past interval.
                                   properties:
                                     periodSeconds:
-                                      description: periodSeconds specifies the window
+                                      description: PeriodSeconds specifies the window
                                         of time for which the policy should hold true.
                                         PeriodSeconds must be greater than zero and
                                         less than or equal to 1800 (30 min).
                                       format: int32
                                       type: integer
                                     type:
-                                      description: type is used to specify the scaling
+                                      description: Type is used to specify the scaling
                                         policy.
                                       type: string
                                     value:
-                                      description: value contains the amount of change
+                                      description: Value contains the amount of change
                                         which is permitted by the policy. It must
                                         be greater than zero
                                       format: int32
@@ -1078,7 +1078,7 @@ spec:
                                   Max is used.
                                 type: string
                               stabilizationWindowSeconds:
-                                description: 'stabilizationWindowSeconds is the number
+                                description: 'StabilizationWindowSeconds is the number
                                   of seconds for which past recommendations should
                                   be considered while scaling up or scaling down.
                                   StabilizationWindowSeconds must be greater than
@@ -1106,18 +1106,18 @@ spec:
                                     which must hold true for a specified past interval.
                                   properties:
                                     periodSeconds:
-                                      description: periodSeconds specifies the window
+                                      description: PeriodSeconds specifies the window
                                         of time for which the policy should hold true.
                                         PeriodSeconds must be greater than zero and
                                         less than or equal to 1800 (30 min).
                                       format: int32
                                       type: integer
                                     type:
-                                      description: type is used to specify the scaling
+                                      description: Type is used to specify the scaling
                                         policy.
                                       type: string
                                     value:
-                                      description: value contains the amount of change
+                                      description: Value contains the amount of change
                                         which is permitted by the policy. It must
                                         be greater than zero
                                       format: int32
@@ -1135,7 +1135,7 @@ spec:
                                   Max is used.
                                 type: string
                               stabilizationWindowSeconds:
-                                description: 'stabilizationWindowSeconds is the number
+                                description: 'StabilizationWindowSeconds is the number
                                   of seconds for which past recommendations should
                                   be considered while scaling up or scaling down.
                                   StabilizationWindowSeconds must be greater than
@@ -1358,16 +1358,15 @@ spec:
                                     of a object,such as kind,name apiVersion
                                   properties:
                                     apiVersion:
-                                      description: apiVersion is the API version of
-                                        the referent
+                                      description: API version of the referent
                                       type: string
                                     kind:
-                                      description: 'kind is the kind of the referent;
-                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      description: 'Kind of the referent; More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                       type: string
                                     name:
-                                      description: 'name is the name of the referent;
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      description: 'Name of the referent; More info:
+                                        http://kubernetes.io/docs/user-guide/identifiers#names'
                                       type: string
                                   required:
                                   - kind
@@ -1690,8 +1689,7 @@ spec:
                     description: "Claims lists the names of resources, defined in
                       spec.resourceClaims, that are used by this container. \n This
                       is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable. It can only be set
-                      for containers."
+                      feature gate. \n This field is immutable."
                     items:
                       description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
@@ -1727,8 +1725,7 @@ spec:
                     description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               shutdownManager:

--- a/controllers/operator.marin3r/discoveryservice_controller.go
+++ b/controllers/operator.marin3r/discoveryservice_controller.go
@@ -87,6 +87,7 @@ func (r *DiscoveryServiceReconciler) Reconcile(ctx context.Context, request ctrl
 		ClientCertificateDuration:         func() (d time.Duration) { d, _ = time.ParseDuration("48h"); return }(),
 		XdsServerPort:                     int32(ds.GetXdsServerPort()),
 		MetricsServerPort:                 int32(ds.GetMetricsPort()),
+		ProbePort:                         int32(ds.GetProbePort()),
 		ServiceType:                       operatorv1alpha1.ClusterIPType,
 		DeploymentImage:                   ds.GetImage(),
 		DeploymentResources:               ds.Resources(),

--- a/examples/local/envoy-client-bootstrap.yaml
+++ b/examples/local/envoy-client-bootstrap.yaml
@@ -56,6 +56,6 @@ static_resources:
           common_tls_context:
             tls_certificates:
               - certificate_chain:
-                  filename: /etc/envoy/tls/envoy-client.crt
+                  filename: /etc/envoy/tls/tls.crt
                 private_key:
-                  filename: /etc/envoy/tls/envoy-client.key
+                  filename: /etc/envoy/tls/tls.key

--- a/hack/gen-certs.sh
+++ b/hack/gen-certs.sh
@@ -3,7 +3,7 @@
 CERTS_BASE_PATH=tmp/certs
 CA_CERT_PATH=${CERTS_BASE_PATH}/ca
 SERVER_CERT_PATH=${CERTS_BASE_PATH}/server
-ENVOY_CERT=${CERTS_BASE_PATH}/envoy-client
+CLIENT_CERT_PATH=${CERTS_BASE_PATH}/client
 
 mkdir -p ${CA_CERT_PATH}
 go run hack/gen_cert.go \
@@ -23,10 +23,11 @@ go run hack/gen_cert.go \
     --signer-key=${CA_CERT_PATH}/tls.key \
     --out ${SERVER_CERT_PATH}/tls
 
+mkdir -p ${CLIENT_CERT_PATH}
 go run hack/gen_cert.go \
     --not-before=$(date '+%Y-%m-%dT%H:%M:%SZ') \
     --not-after=$(date '+%Y-%m-%dT%H:%M:%SZ' -d '+10 years') \
     --signer-cert=${CA_CERT_PATH}/tls.crt \
     --common-name=envoy-client \
     --signer-key=${CA_CERT_PATH}/tls.key \
-    --out ${ENVOY_CERT}
+    --out ${CLIENT_CERT_PATH}/tls

--- a/pkg/discoveryservice/xds_server.go
+++ b/pkg/discoveryservice/xds_server.go
@@ -99,7 +99,7 @@ func NewXdsServer(ctx context.Context, xDSPort uint, tlsConfig *tls.Config, logg
 }
 
 // Start starts an xDS server at the given port.
-func (xdss *XdsServer) Start(client kubernetes.Interface, namespace string, stopCh <-chan struct{}) error {
+func (xdss *XdsServer) Start(client kubernetes.Interface, namespace string) error {
 
 	// gRPC golang library sets a very small upper bound for the number gRPC/h2
 	// streams over a single TCP connection. If a proxy multiplexes requests over
@@ -119,7 +119,7 @@ func (xdss *XdsServer) Start(client kubernetes.Interface, namespace string, stop
 	)
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", xdss.xDSPort))
 	if err != nil {
-		setupLog.Error(err, "Error starting aDS server")
+		setupLog.Error(err, "Error starting ADS server")
 		return err
 	}
 
@@ -146,7 +146,7 @@ func (xdss *XdsServer) Start(client kubernetes.Interface, namespace string, stop
 	// wait until channel stopCh closed or an error is received
 	select {
 
-	case <-stopCh:
+	case <-xdss.ctx.Done():
 		setupLog.Info("shutting down xds server")
 		close(stopGC)
 		stopped := make(chan struct{})

--- a/pkg/reconcilers/operator/discoveryservice/generators/certificate_client.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/certificate_client.go
@@ -2,7 +2,6 @@ package generators
 
 import (
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
-	"github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,12 +16,12 @@ func (cfg *GeneratorOptions) ClientCertificate() func() *operatorv1alpha1.Discov
 				APIVersion: operatorv1alpha1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      defaults.SidecarClientCertificate,
+				Name:      cfg.ClientCertName(),
 				Namespace: cfg.Namespace,
 				Labels:    cfg.labels(),
 			},
 			Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
-				CommonName: defaults.SidecarClientCertificate,
+				CommonName: cfg.ClientCertName(),
 				ValidFor:   int64(cfg.ClientCertificateDuration.Seconds()),
 				Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
 					CASigned: &operatorv1alpha1.CASignedConfig{
@@ -32,7 +31,7 @@ func (cfg *GeneratorOptions) ClientCertificate() func() *operatorv1alpha1.Discov
 						}},
 				},
 				SecretRef: corev1.SecretReference{
-					Name: defaults.SidecarClientCertificate,
+					Name: cfg.ClientCertName(),
 				},
 			},
 		}

--- a/pkg/reconcilers/operator/discoveryservice/generators/deployment_test.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/deployment_test.go
@@ -6,9 +6,9 @@ import (
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
 	"github.com/3scale-ops/marin3r/pkg/util/pointer"
+	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -36,6 +36,7 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 				ClientCertificateDuration:         time.Duration(10),
 				XdsServerPort:                     1000,
 				MetricsServerPort:                 1001,
+				ProbePort:                         1002,
 				ServiceType:                       operatorv1alpha1.ClusterIPType,
 				DeploymentImage:                   "test:latest",
 				DeploymentResources:               corev1.ResourceRequirements{},
@@ -98,6 +99,15 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: "client-cert",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName:  "envoy-sidecar-client-cert",
+											DefaultMode: pointer.New(int32(420)),
+										},
+									},
+								},
 							},
 							Containers: []corev1.Container{
 								{
@@ -107,8 +117,10 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 										"discovery-service",
 										"--server-certificate-path=/etc/marin3r/tls/server",
 										"--ca-certificate-path=/etc/marin3r/tls/ca",
+										"--client-certificate-path=/etc/marin3r/tls/client",
 										"--xdss-port=1000",
 										"--metrics-bind-address=:1001",
+										"--health-probe-bind-address=:1002",
 										"--debug",
 									},
 									Ports: []corev1.ContainerPort{
@@ -132,6 +144,24 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 											},
 										}},
 									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path:   "/healthz",
+												Port:   intstr.FromInt(1002),
+												Scheme: corev1.URISchemeHTTP,
+											},
+										},
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path:   "/readyz",
+												Port:   intstr.FromInt(1002),
+												Scheme: corev1.URISchemeHTTP,
+											},
+										},
+									},
 									Resources: corev1.ResourceRequirements{},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -143,6 +173,11 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 											Name:      "ca-cert",
 											ReadOnly:  true,
 											MountPath: "/etc/marin3r/tls/ca/",
+										},
+										{
+											Name:      "client-cert",
+											ReadOnly:  true,
+											MountPath: "/etc/marin3r/tls/client/",
 										},
 									},
 									TerminationMessagePath:   corev1.TerminationMessagePathDefault,
@@ -182,8 +217,9 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := tt.opts
-			if got := cfg.Deployment(tt.args.hash)(); !equality.Semantic.DeepEqual(got, tt.want) {
-				t.Errorf("GeneratorOptions.Deployment() = %v, want %v", got, tt.want)
+			got := cfg.Deployment(tt.args.hash)()
+			if diff := cmp.Diff(got, tt.want); len(diff) > 0 {
+				t.Errorf("GeneratorOptions.Deployment() = got diff %v", diff)
 			}
 		})
 	}

--- a/pkg/reconcilers/operator/discoveryservice/generators/generator.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/generator.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	operatorv1alpha1 "github.com/3scale-ops/marin3r/apis/operator.marin3r/v1alpha1"
+	"github.com/3scale-ops/marin3r/pkg/envoy/container/defaults"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -20,6 +21,7 @@ type GeneratorOptions struct {
 	ClientCertificateDuration         time.Duration
 	XdsServerPort                     int32
 	MetricsServerPort                 int32
+	ProbePort                         int32
 	ServiceType                       operatorv1alpha1.ServiceType
 	DeploymentImage                   string
 	DeploymentResources               corev1.ResourceRequirements
@@ -42,6 +44,10 @@ func (cfg *GeneratorOptions) RootCertName() string {
 
 func (cfg *GeneratorOptions) ServerCertName() string {
 	return fmt.Sprintf("%s-%s", cfg.ServerCertificateNamePrefix, cfg.InstanceName)
+}
+
+func (cfg *GeneratorOptions) ClientCertName() string {
+	return defaults.SidecarClientCertificate
 }
 
 func (cfg *GeneratorOptions) ResourceName() string {


### PR DESCRIPTION
Some improvements to the discovery service, most notable the implementation of healthz checks for this pod. I have added a gRPC healthz service to the same gRPC server where the xDS service runs. This checkis then  aggregated by controller-runtime with the typical "ping" healthz checks we use for controllers.

This PR closes #46

/kind feature
/priority important-soon
/assign
/ok-to-test