### PR TITLE
Add deprecation notice on field

### DIFF
--- a/apis/marin3r/v1alpha1/resources.go
+++ b/apis/marin3r/v1alpha1/resources.go
@@ -215,12 +215,12 @@ func (res *EnvoyResource) Resource(rType envoy.Type, serialization envoy_seriali
 // to take a secret from. Only Secrets within the same namespace can
 // be referred.
 type EnvoySecretResource struct {
-	// Name of the envoy resource. If ref is not set, a Secret with this same
-	// name will be fetched from within the namespace.
+	// Name of the envoy tslCerticate secret resource. The certificate will be fetched
+	// from a Kubernetes Secrets of type 'kubernetes.io/tls' with this same name.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Name string `json:"name"`
-	// Ref is a reference to a Kubernetes Secret of type "kubernetes.io/tls". The value of 'ref'
-	// cannot point to a different namespace.
+	// DEPRECATED: this field is deprecated and it's value will be ignored. The 'name' of the
+	// Kubernetes Secret must match the 'name' field.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:io.kubernetes:SecretReference"
 	// +optional
 	Ref *corev1.SecretReference `json:"ref,omitempty"`

--- a/apis/operator.marin3r/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/operator.marin3r/v1alpha1/zz_generated.deepcopy.go
@@ -351,6 +351,11 @@ func (in *DiscoveryServiceSpec) DeepCopyInto(out *DiscoveryServiceSpec) {
 		*out = new(uint32)
 		**out = **in
 	}
+	if in.ProbePort != nil {
+		in, out := &in.ProbePort, &out.ProbePort
+		*out = new(uint32)
+		**out = **in
+	}
 	if in.ServiceConfig != nil {
 		in, out := &in.ServiceConfig, &out.ServiceConfig
 		*out = new(ServiceConfig)


### PR DESCRIPTION
Add deprecation notice on the `spec.envoyResources.secrets[*].ref` field. The code ignores this field and should be removed in an upcoming release. Actually use of the whole `spec.envoyResources` is now deprecated, but being explicit with this anyway.

Also adding some changes to the generated file `apis/operator.marin3r/v1alpha1/zz_generated.deepcopy.go`  which I missed from a previous PR.

/kind documentation
/priority important-soon
/assign
/ok-to-test