### PR TITLE
Fix rollout of the discovery service

### DIFF
--- a/cmd/discoveryservice.go
+++ b/cmd/discoveryservice.go
@@ -95,11 +95,12 @@ func runDiscoveryService(cmd *cobra.Command, args []string) {
 	ctx := signals.SetupSignalHandler()
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:                 dsScheme,
-		MetricsBindAddress:     metricsAddr,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         false,
-		Namespace:              os.Getenv("WATCH_NAMESPACE"),
+		Scheme:                     dsScheme,
+		MetricsBindAddress:         metricsAddr,
+		HealthProbeBindAddress:     probeAddr,
+		LeaderElectionID:           "2cfbe7d6.marin3r.3scale.net",
+		LeaderElectionResourceLock: "leases",
+		Namespace:                  os.Getenv("WATCH_NAMESPACE"),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/discoveryservice/xds_server.go
+++ b/pkg/discoveryservice/xds_server.go
@@ -158,7 +158,8 @@ func (xdss *XdsServer) Start(client kubernetes.Interface, namespace string) erro
 		close(stopGC)
 		stopped := make(chan struct{})
 		go func() {
-			grpcServer.GracefulStop()
+			// don't wait, stop immediately
+			grpcServer.Stop()
 			close(stopped)
 		}()
 

--- a/pkg/reconcilers/operator/discoveryservice/generators/deployment.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/deployment.go
@@ -160,17 +160,7 @@ func (cfg *GeneratorOptions) Deployment(hash string) func() *appsv1.Deployment {
 					},
 				},
 				Strategy: appsv1.DeploymentStrategy{
-					Type: appsv1.RollingUpdateDeploymentStrategyType,
-					RollingUpdate: &appsv1.RollingUpdateDeployment{
-						MaxUnavailable: &intstr.IntOrString{
-							Type:   intstr.String,
-							StrVal: "25%",
-						},
-						MaxSurge: &intstr.IntOrString{
-							Type:   intstr.String,
-							StrVal: "25%",
-						},
-					},
+					Type: appsv1.RecreateDeploymentStrategyType,
 				},
 				RevisionHistoryLimit:    pointer.New(int32(10)),
 				ProgressDeadlineSeconds: pointer.New(int32(600)),

--- a/pkg/reconcilers/operator/discoveryservice/generators/deployment_test.go
+++ b/pkg/reconcilers/operator/discoveryservice/generators/deployment_test.go
@@ -196,17 +196,7 @@ func TestGeneratorOptions_Deployment(t *testing.T) {
 						},
 					},
 					Strategy: appsv1.DeploymentStrategy{
-						Type: appsv1.RollingUpdateDeploymentStrategyType,
-						RollingUpdate: &appsv1.RollingUpdateDeployment{
-							MaxUnavailable: &intstr.IntOrString{
-								Type:   intstr.String,
-								StrVal: "25%",
-							},
-							MaxSurge: &intstr.IntOrString{
-								Type:   intstr.String,
-								StrVal: "25%",
-							},
-						},
+						Type: appsv1.RecreateDeploymentStrategyType,
 					},
 					RevisionHistoryLimit:    pointer.New(int32(10)),
 					ProgressDeadlineSeconds: pointer.New(int32(600)),


### PR DESCRIPTION
With the addition of health checks, the rollout of new versions of the discovery service is slower because the new pod takees some seconds to pass the health checks. This makes that both the old controllers and the new ones run in parallel for some seconds, trying to write to the same EnvoyConfigRevisions and causing problems. To fix this:
* Change the Deployment rollout strategy to "replace"
* Add controller lock
* Shutdown the xDS sever faster, without graceful shutdown

I have tested an upgrade from v0.11.1 to a version with the changes in this PR and it fixes the problems.

/kind bug
/priority critical-urgent
/assign
/ok-to-test