### PR TITLE
Update hg actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,30 +7,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "1.19"
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
-
-      - uses: actions/cache@v2
-        with:
-          path: ./tmp
-          key: ${{ runner.os }}-tmp
-
-      - uses: actions/cache@v2
-        with:
-          path: ./bin
-          key: ${{ runner.os }}-bin
 
       - name: Build image
         run: make docker-build
@@ -41,7 +25,7 @@ jobs:
 
       - name: Login to quay.io/3scale
         if: ${{ env.NEW_RELEASE != '' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.REGISTRY_USER }}

--- a/.github/workflows/catalog.yaml
+++ b/.github/workflows/catalog.yaml
@@ -1,0 +1,25 @@
+name: catalog
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - catalog/marin3r/stable-channel.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to quay.io/3scale
+        if: ${{ env.NEW_RELEASE != '' }}
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build & push catalog
+        run: make catalog-publish

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,31 +9,15 @@ on:
 jobs:
   test:
     if: ${{ github.event.label.name == 'ok-to-test' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: "1.19"
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
-
-      - uses: actions/cache@v2
-        with:
-          path: ./tmp
-          key: ${{ runner.os }}-tmp
-
-      - uses: actions/cache@v2
-        with:
-          path: ./bin
-          key: ${{ runner.os }}-bin
 
       - name: Run tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,9 @@ prepare-alpha-release: generate fmt vet manifests go-generate bundle ## Generate
 prepare-stable-release: generate fmt vet manifests go-generate bundle refdocs ## Generates bundle manifests for stable channel release
 	$(MAKE) bundle CHANNELS=alpha,stable DEFAULT_CHANNEL=stable
 
-bundle-publish: docker-build docker-push bundle-build bundle-push catalog-build catalog-push catalog-retag-latest ## Generates and pushes all required images for a release
+bundle-publish: docker-build docker-push bundle-build bundle-push ## Builds and pushes operator and bundle images
+
+catalog-publish: catalog-build catalog-push catalog-retag-latest ## Builds and pushes the catalog image
 
 get-new-release: ## Checks if a release with the name $(VERSION) already exists in https://github.com/3scale-ops/marin3r/releases
 	@hack/new-release.sh v$(VERSION)


### PR DESCRIPTION
* Updates versions of the actions used.
* Remove the caching actions as actions/setup-go@v4 already has built-in caching enabled by default
* Add an action to publish the operator catalog when changes are made to the stable channel

/kind feature
/priority important-longterm
/assign
