### PR TITLE
Don't allow cross-namespace Secrets access

### DIFF
--- a/internal/pkg/reconcilers/operator/discoveryservicecertificate/providers/marin3r/crud.go
+++ b/internal/pkg/reconcilers/operator/discoveryservicecertificate/providers/marin3r/crud.go
@@ -210,10 +210,26 @@ func (cp *CertificateProvider) VerifyCertificate(ctx context.Context) error {
 // getIssuerCertificate returns the issuer certificate for a DiscoveryServiceCertificate resource
 func (cp *CertificateProvider) getIssuerCertificate(ctx context.Context) (*x509.Certificate, interface{}, error) {
 	if cp.dsc.Spec.Signer.CASigned != nil {
+		caNamespace := cp.dsc.Spec.Signer.CASigned.SecretRef.Namespace
+		dscNamespace := cp.dsc.GetNamespace()
+
+		// Default to current namespace if not specified
+		if caNamespace == "" {
+			caNamespace = dscNamespace
+		}
+
+		// Enforce same-namespace requirement for security
+		if caNamespace != dscNamespace {
+			return nil, nil, fmt.Errorf(
+				"DiscoveryServiceCertificate cannot reference Secrets in other namespaces: "+
+					"caSecretRef is in namespace '%s' but DiscoveryServiceCertificate is in '%s'",
+				caNamespace, dscNamespace)
+		}
+
 		secret := &corev1.Secret{}
 		key := types.NamespacedName{
 			Name:      cp.dsc.Spec.Signer.CASigned.SecretRef.Name,
-			Namespace: cp.dsc.Spec.Signer.CASigned.SecretRef.Namespace,
+			Namespace: caNamespace,
 		}
 
 		if err := cp.client.Get(ctx, key, secret); err != nil {

--- a/internal/pkg/reconcilers/operator/discoveryservicecertificate/providers/marin3r/crud_test.go
+++ b/internal/pkg/reconcilers/operator/discoveryservicecertificate/providers/marin3r/crud_test.go
@@ -442,6 +442,38 @@ func TestCertificateProvider_VerifyCertificate(t *testing.T) {
 					}}},
 			wantErr: true,
 		},
+		{
+			name: "Verify returns an error when issuer is in different namespace",
+			fields: fields{
+				ctx:    context.TODO(),
+				logger: ctrl.Log.WithName("test"),
+				client: fake.NewClientBuilder().WithScheme(s).WithObjects(
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "issuer", Namespace: "other-namespace"},
+						Data: map[string][]byte{
+							tlsCertificateKey: test.TestIssuerCertificate(),
+							tlsPrivateKeyKey:  test.TestIssuerKey(),
+						}},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: "test"},
+						Data: map[string][]byte{
+							tlsCertificateKey: test.TestValidCertificate(),
+							tlsPrivateKeyKey:  []byte("xxxx"),
+						}},
+				).Build(),
+				scheme: s,
+				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
+					ObjectMeta: metav1.ObjectMeta{Name: "dsc", Namespace: "test"},
+					Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
+						Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
+							CASigned: &operatorv1alpha1.CASignedConfig{
+								SecretRef: corev1.SecretReference{Name: "issuer", Namespace: "other-namespace"},
+							},
+						},
+						SecretRef: corev1.SecretReference{Name: "secret"},
+					}}},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -537,6 +569,78 @@ func TestCertificateProvider_getIssuerCertificate(t *testing.T) {
 			want:    nil,
 			want1:   nil,
 			wantErr: true,
+		},
+		{
+			name: "Returns an error when attempting to access Secret in different namespace",
+			fields: fields{
+				ctx:    context.TODO(),
+				logger: ctrl.Log.WithName("test"),
+				client: fake.NewClientBuilder().WithScheme(s).WithObjects(
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "issuer", Namespace: "other-namespace"},
+						Type:       corev1.SecretTypeTLS,
+						Data: map[string][]byte{
+							tlsCertificateKey: test.TestIssuerCertificate(),
+							tlsPrivateKeyKey:  test.TestIssuerKey(),
+						},
+					}).Build(),
+				scheme: s,
+				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
+					ObjectMeta: metav1.ObjectMeta{Name: "dsc", Namespace: "test"},
+					Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
+						CommonName: "test",
+						ValidFor:   3600,
+						Hosts:      []string{"example.test"},
+						Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
+							CASigned: &operatorv1alpha1.CASignedConfig{
+								SecretRef: corev1.SecretReference{Name: "issuer", Namespace: "other-namespace"},
+							},
+						},
+						SecretRef: corev1.SecretReference{Name: "secret"},
+					}}},
+			want:    nil,
+			want1:   nil,
+			wantErr: true,
+		},
+		{
+			name: "Allows access when caSecretRef namespace is empty (defaults to same namespace)",
+			fields: fields{
+				ctx:    context.TODO(),
+				logger: ctrl.Log.WithName("test"),
+				client: fake.NewClientBuilder().WithScheme(s).WithObjects(
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: "issuer", Namespace: "test"},
+						Type:       corev1.SecretTypeTLS,
+						Data: map[string][]byte{
+							tlsCertificateKey: test.TestIssuerCertificate(),
+							tlsPrivateKeyKey:  test.TestIssuerKey(),
+						},
+					}).Build(),
+				scheme: s,
+				dsc: &operatorv1alpha1.DiscoveryServiceCertificate{
+					ObjectMeta: metav1.ObjectMeta{Name: "dsc", Namespace: "test"},
+					Spec: operatorv1alpha1.DiscoveryServiceCertificateSpec{
+						CommonName: "test",
+						ValidFor:   3600,
+						Hosts:      []string{"example.test"},
+						Signer: operatorv1alpha1.DiscoveryServiceCertificateSigner{
+							CASigned: &operatorv1alpha1.CASignedConfig{
+								SecretRef: corev1.SecretReference{Name: "issuer", Namespace: ""},
+							},
+						},
+						SecretRef: corev1.SecretReference{Name: "secret"},
+					}}},
+			want: func() *x509.Certificate {
+				cert, _ := pki.LoadX509Certificate(test.TestIssuerCertificate())
+
+				return cert
+			}(),
+			want1: func() interface{} {
+				signer, _ := pki.DecodePrivateKeyBytes(test.TestIssuerKey())
+
+				return signer
+			}(),
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Users with permission to create DiscoveryServiceCertificate resources in one
namespace can indirectly read Secrets from other namespaces, completely
bypassing Kubernetes RBAC security boundaries.